### PR TITLE
15 fix incorrect vrdr ig links in library definitions

### DIFF
--- a/src/main/java/edu/gatech/chai/VRDR/cli/Console.java
+++ b/src/main/java/edu/gatech/chai/VRDR/cli/Console.java
@@ -1,7 +1,7 @@
 package edu.gatech.chai.VRDR.cli;
 
 import edu.gatech.chai.VRDR.context.VRDRFhirContext;
-import edu.gatech.chai.VRDR.messaging.util.BaseMessage;
+import edu.gatech.chai.VRDR.messaging.BaseMessage;
 import edu.gatech.chai.VRDR.messaging.util.MessagingExample;
 import org.hl7.fhir.r4.model.Bundle;
 import picocli.CommandLine;
@@ -51,10 +51,20 @@ public class Console {
         }
 
         if (outputXml) {
-            writeToFile(BaseMessage.bundleToXml(ctx, message, true), outputFile);
+            String bundleStr = ctx
+                    .getCtx()
+                    .newXmlParser()
+                    .setPrettyPrint(true)
+                    .encodeResourceToString(message);
+            writeToFile(bundleStr, outputFile);
         }
         else {
-            writeToFile(BaseMessage.bundleToJson(ctx, message, true), outputFile);
+            String bundleStr = ctx
+                    .getCtx()
+                    .newJsonParser()
+                    .setPrettyPrint(true)
+                    .encodeResourceToString(message);
+            writeToFile(bundleStr, outputFile);
         }
     }
 

--- a/src/main/java/edu/gatech/chai/VRDR/context/VRDRFhirContext.java
+++ b/src/main/java/edu/gatech/chai/VRDR/context/VRDRFhirContext.java
@@ -30,5 +30,3 @@ public class VRDRFhirContext extends VRDRFhirContextDataStructuresOnly {
                 Bundle.class);
     }
 }
-
-

--- a/src/main/java/edu/gatech/chai/VRDR/context/VRDRFhirContextDataStructuresOnly.java
+++ b/src/main/java/edu/gatech/chai/VRDR/context/VRDRFhirContextDataStructuresOnly.java
@@ -8,6 +8,7 @@ public class VRDRFhirContextDataStructuresOnly {
 
 	public VRDRFhirContextDataStructuresOnly() {
 		ctx = FhirContext.forR4();
+		// these types come from http://hl7.org/fhir/us/vrdr/index.html
 		ctx.setDefaultTypeForProfile("http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-activity-at-time-of-death",
 				ActivityAtTimeOfDeath.class);
 		ctx.setDefaultTypeForProfile("http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-automated-underlying-cause-of-death",
@@ -16,7 +17,7 @@ public class VRDRFhirContextDataStructuresOnly {
 				AutopsyPerformedIndicator.class);
 		ctx.setDefaultTypeForProfile("http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-birth-record-identifier",
 				BirthRecordIdentifier.class);
-		ctx.setDefaultTypeForProfile("http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-coded-content-bundle",
+		ctx.setDefaultTypeForProfile( "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-coded-bundle",
 				CauseOfDeathCodedContentBundle.class);
 		ctx.setDefaultTypeForProfile("http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1",
 				CauseOfDeathPart1.class);
@@ -58,7 +59,7 @@ public class VRDRFhirContextDataStructuresOnly {
 				DecedentSpouse.class);
 		ctx.setDefaultTypeForProfile("http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-usual-work",
 				DecedentUsualWork.class);
-		ctx.setDefaultTypeForProfile("http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-demographic-coded-content-bundle",
+		ctx.setDefaultTypeForProfile("http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-demographic-coded-bundle",
 				DemographicCodedContentBundle.class);
 		ctx.setDefaultTypeForProfile("http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-disposition-location",
 				DispositionLocation.class);
@@ -86,7 +87,7 @@ public class VRDRFhirContextDataStructuresOnly {
 				RecordAxisCauseOfDeath.class);
 		ctx.setDefaultTypeForProfile("http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-surgery-date",
 				SurgeryDate.class);
-		ctx.setDefaultTypeForProfile("http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-Tobacco-Use-Contributed-To-Death",
+		ctx.setDefaultTypeForProfile("http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-tobacco-use-contributed-to-death",
 				TobaccoUseContributedToDeath.class);
 	}
 

--- a/src/main/java/edu/gatech/chai/VRDR/messaging/AcknowledgementMessage.java
+++ b/src/main/java/edu/gatech/chai/VRDR/messaging/AcknowledgementMessage.java
@@ -39,6 +39,8 @@ public class AcknowledgementMessage extends BaseMessage {
         header.getSource().setEndpoint(source);
         setMessageDestination(destination);
         MessageHeader.MessageHeaderResponseComponent resp = new MessageHeader.MessageHeaderResponseComponent();
+        // strip off if messageId of header.id has prefix 'urn:uuid:'
+        messageId = messageId.startsWith("urn:uuid:") ?  messageId.substring(9) : messageId;
         resp.setIdentifier(messageId);
         resp.setCode(MessageHeader.ResponseType.OK);
         header.setResponse(resp);

--- a/src/main/java/edu/gatech/chai/VRDR/messaging/AcknowledgementMessage.java
+++ b/src/main/java/edu/gatech/chai/VRDR/messaging/AcknowledgementMessage.java
@@ -1,10 +1,10 @@
 package edu.gatech.chai.VRDR.messaging;
 
 import ca.uhn.fhir.model.api.annotation.ResourceDef;
-import edu.gatech.chai.VRDR.messaging.util.BaseMessage;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.MessageHeader;
+import org.hl7.fhir.r4.model.ResourceType;
 
 @ResourceDef(name = "AcknowledgementMessage", profile = "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-AcknowledgementMessage")
 public class AcknowledgementMessage extends BaseMessage {
@@ -20,7 +20,7 @@ public class AcknowledgementMessage extends BaseMessage {
     }
 
     public AcknowledgementMessage(BaseMessage messageToAck) {
-        this(messageToAck == null ? null : messageToAck.getMessageId(),
+        this(messageToAck == null ? null : messageToAck.getId(),
                 messageToAck == null ? null : messageToAck.getMessageSource(),
                 messageToAck == null ? null : messageToAck.getMessageDestination());
         setCertNo(messageToAck == null ? null : messageToAck.getCertNo());
@@ -36,14 +36,14 @@ public class AcknowledgementMessage extends BaseMessage {
 
     public AcknowledgementMessage(String messageId, String destination, String source) {
         super(MESSAGE_TYPE);
-        header.getSource().setEndpoint(source);
+        messageHeader.getSource().setEndpoint(source);
         setMessageDestination(destination);
         MessageHeader.MessageHeaderResponseComponent resp = new MessageHeader.MessageHeaderResponseComponent();
         // strip off if messageId of header.id has prefix 'urn:uuid:'
-        messageId = messageId.startsWith("urn:uuid:") ?  messageId.substring(9) : messageId;
+        messageId = messageId != null && messageId.startsWith("urn:uuid:") ?  messageId.substring(9) : messageId;
         resp.setIdentifier(messageId);
         resp.setCode(MessageHeader.ResponseType.OK);
-        header.setResponse(resp);
+        messageHeader.setResponse(resp);
     }
 
     public AcknowledgementMessage(String messageId, String destination) {
@@ -55,28 +55,28 @@ public class AcknowledgementMessage extends BaseMessage {
     }
 
     public String getAckedMessageId() {
-        return header != null && header.getResponse() != null ? header.getResponse().getIdentifier() : null;
+        return messageHeader != null && messageHeader.getResponse() != null ? messageHeader.getResponse().getIdentifier() : null;
     }
 
     public void setAckedMessageId(String value) {
-        if (header.getResponse() == null) {
-            header.setResponse(new MessageHeader.MessageHeaderResponseComponent());
-            header.getResponse().setCode(MessageHeader.ResponseType.OK);
+        if (messageHeader.getResponse() == null) {
+            messageHeader.setResponse(new MessageHeader.MessageHeaderResponseComponent());
+            messageHeader.getResponse().setCode(MessageHeader.ResponseType.OK);
         }
-        header.getResponse().setIdentifier(value);
+        messageHeader.getResponse().setIdentifier(value);
     }
 
     public Integer getBlockCount() {
-        if (record == null) {
+        if (messageParameters == null) {
             return null;
         }
-        if (!record.hasParameter("block_count")) {
+        if (!messageParameters.hasParameter("block_count")) {
             return null;
         }
-        if (!(record.getParameter("block_count") instanceof IntegerType)) {
+        if (!(messageParameters.getParameter("block_count") instanceof IntegerType)) {
             return null;
         }
-        IntegerType blockCountType = (IntegerType) record.getParameter("block_count");
+        IntegerType blockCountType = (IntegerType) messageParameters.getParameter("block_count");
         if (blockCountType == null) {
             return null;
         }
@@ -85,11 +85,10 @@ public class AcknowledgementMessage extends BaseMessage {
 
     public void setBlockCount(Integer value) {
         if (value != null && value > 1) {
-            record.setParameter("block_count", new IntegerType(value));
+            messageParameters.setParameter("block_count", new IntegerType(value));
         }
         else {
-            record.setParameter("block_count", (IntegerType)null);
+            messageParameters.setParameter("block_count", (IntegerType)null);
         }
     }
-
 }

--- a/src/main/java/edu/gatech/chai/VRDR/messaging/BaseMessage.java
+++ b/src/main/java/edu/gatech/chai/VRDR/messaging/BaseMessage.java
@@ -1,9 +1,10 @@
-package edu.gatech.chai.VRDR.messaging.util;
+package edu.gatech.chai.VRDR.messaging;
 
 import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.parser.LenientErrorHandler;
 import edu.gatech.chai.VRDR.context.VRDRFhirContext;
-import edu.gatech.chai.VRDR.messaging.DeathRecordSubmissionMessage;
+import edu.gatech.chai.VRDR.messaging.util.DocumentBundler;
+import edu.gatech.chai.VRDR.messaging.util.MessageParseException;
 import edu.gatech.chai.VRDR.model.DeathCertificateDocument;
 import edu.gatech.chai.VRDR.model.DeathDate;
 import edu.gatech.chai.VRDR.model.DeathLocation;
@@ -16,30 +17,131 @@ import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
-public abstract class BaseMessage extends Bundle {
+public class BaseMessage extends Bundle {
 
-    protected Bundle messageBundle;
-    protected Parameters record;
-    protected MessageHeader header;
+    protected Parameters messageParameters;
+    protected MessageHeader messageHeader;
+
+    public static void addBundleEntryAndLinkToHeader(Bundle bundle, MessageHeader header, Bundle innerBundle) {
+        // remove any existing entries of the same type
+        bundle.getEntry().removeIf(entry ->
+                innerBundle.getResourceType().equals(entry.getResource().getResourceType()));
+        // remove the header link
+        header.setFocus(null);
+        // create a new bundle entry
+        Bundle.BundleEntryComponent newEntry = new Bundle.BundleEntryComponent();
+        String innerBundleRef = innerBundle.getId();
+        if (innerBundleRef != null && !innerBundleRef.startsWith("urn:uuid:")) {
+            innerBundleRef = "urn:uuid:" + innerBundleRef;
+        }
+        newEntry.setFullUrl(innerBundleRef);
+        newEntry.setResource(innerBundle);
+        newEntry.getResource().setId(ensureBareId(innerBundle.getId()));
+        // add the new entry to the bundle
+        bundle.addEntry(newEntry);
+        // add the new entry reference to the header
+        header.addFocus(new Reference(innerBundleRef));
+    }
+
+    public static String ensureRefPrefix(String id) {
+        if (id != null && !id.startsWith("urn:uuid:")) {
+            id = "urn:uuid:" + id;
+        }
+        return id;
+    }
+
+    public static String ensureBareId(String id) {
+        if (id != null && id.startsWith("urn:uuid:")) {
+            id = id.substring("urn:uuid:".length(), id.length());
+        }
+        return id;
+    }
+
+    protected BaseMessage() {
+        super();
+        setId(UUID.randomUUID().toString());
+        setType(BundleType.MESSAGE);
+        setTimestamp(new Date());
+    }
 
     protected BaseMessage(Bundle messageBundle) {
-        this(messageBundle, false, false, false);
+        this(messageBundle, false);
     }
 
-    protected BaseMessage(Bundle messageBundle, boolean ignoreMissingEntries, boolean ignoreBundleType, boolean ignoreEventType) {
-        this.messageBundle = messageBundle;
+    protected BaseMessage(Bundle messageBundle, boolean ignoreExceptions) {
+        this();
+
+        // configure bundle
+        setId(messageBundle.getId());
+        setTimestamp(messageBundle.getTimestamp());
         BundleType bundleType = messageBundle == null ? BundleType.NULL : messageBundle.getType();
-        if (!ignoreBundleType && bundleType != BundleType.MESSAGE) {
+        if (!ignoreExceptions && bundleType != BundleType.MESSAGE) {
             throw new MessageParseException("The FHIR Bundle must be of type message, not " + bundleType.toString(), messageBundle);
         }
-        header = CommonUtil.findEntry(messageBundle, MessageHeader.class, ignoreMissingEntries);
-        record = CommonUtil.findEntry(messageBundle, Parameters.class, ignoreMissingEntries);
-        if (!ignoreEventType && !isMessageEventMatchingMessageType(getIGMessageType())) {
+        setType(bundleType);
+
+        messageHeader = CommonUtil.findEntry(messageBundle, MessageHeader.class, ignoreExceptions);
+        messageParameters = CommonUtil.findEntry(messageBundle, Parameters.class, ignoreExceptions);
+        if (!ignoreExceptions && !isMessageEventMatchingMessageType(getIGMessageType())) {
             throw new MessageParseException(getMessageEventTypeMismatchErrorMessage(getIGMessageType()), messageBundle);
         }
+
+        addBundleEntryForHeaderAndParameters();
+    }
+    protected BaseMessage(String messageType) {
+        this(messageType, true);
     }
 
-    protected <T extends Bundle> void updateDocumentBundle(Class<T> tClass, DocumentBundler<T> documentBundler) {
+    // to support jurisdictions who want to bypass adding meta profile by default
+    protected BaseMessage(String messageType, boolean includeMetaProfiles) {
+        this();
+
+        // Start with a message header
+        messageHeader = new MessageHeader();
+        if (includeMetaProfiles) {
+            messageHeader.getMeta().addProfile("http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-SubmissionHeader");
+        }
+        messageHeader.setId(UUID.randomUUID().toString());
+        messageHeader.setEvent(new UriType(messageType));
+
+        // add message header source
+        MessageHeader.MessageSourceComponent source = new MessageHeader.MessageSourceComponent();
+        messageHeader.setSource(source);
+
+        // add message header destination
+        MessageHeader.MessageDestinationComponent destination = new MessageHeader.MessageDestinationComponent();
+        destination.setEndpoint(DeathRecordSubmissionMessage.MESSAGE_TYPE);
+        List<MessageHeader.MessageDestinationComponent> destinationComponents = new ArrayList<>();
+        destinationComponents.add(destination);
+        messageHeader.setDestination(destinationComponents);
+
+        // setup parameters and reference in header
+        messageParameters = new Parameters();
+        if (includeMetaProfiles) {
+            messageParameters.getMeta().addProfile("http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-MessageParameters");
+        }
+        messageParameters.setId(UUID.randomUUID().toString());
+        messageHeader.addFocus(new Reference(ensureRefPrefix(messageParameters.getId())));
+        addBundleEntryForHeaderAndParameters();
+    }
+
+    protected void addBundleEntryForHeaderAndParameters() {
+        // add message header to bundle
+        Bundle.BundleEntryComponent headerBundleComponent = new Bundle.BundleEntryComponent();
+        headerBundleComponent.setFullUrl(ensureRefPrefix(messageHeader.getId()));
+        headerBundleComponent.setResource(messageHeader);
+        headerBundleComponent.getResource().setId(ensureBareId(messageHeader.getId()));
+        addEntry(headerBundleComponent);
+
+        // add parameters resource to bundle
+        Bundle.BundleEntryComponent parametersBundleComponent = new Bundle.BundleEntryComponent();
+        parametersBundleComponent.setFullUrl(ensureRefPrefix(messageParameters.getId()));
+        parametersBundleComponent.setResource(messageParameters);
+        parametersBundleComponent.getResource().setId(ensureBareId(messageParameters.getId()));
+        addEntry(parametersBundleComponent);
+    }
+
+    protected <T extends Bundle> void setDocumentBundleFromMessageBundle(Class<T> tClass, DocumentBundler<T> documentBundler, Bundle messageBundle) {
         try {
             Bundle bundle = CommonUtil.findEntry(messageBundle, tClass);
             if (bundle == null) {
@@ -55,10 +157,13 @@ public abstract class BaseMessage extends Bundle {
         }
     }
 
-    protected abstract String getIGMessageType(); // override for specific IG message types in subclass
+    protected String getIGMessageType() {
+        return null; // override for specific IG message types in subclass
+    }
+
 
     protected String getMessageEventType() {
-        return header != null && header.hasEventUriType() ? header.getEventUriType().getValue() : null;
+        return messageHeader != null && messageHeader.hasEventUriType() ? messageHeader.getEventUriType().getValue() : null;
     }
 
     protected boolean isMessageEventMatchingMessageType(String messageType) {
@@ -68,59 +173,6 @@ public abstract class BaseMessage extends Bundle {
 
     protected String getMessageEventTypeMismatchErrorMessage(String messageType) {
         return "Message event uri type " + getMessageEventType() + " does not match the expected message type " + messageType;
-    }
-
-    protected BaseMessage(String messageType) {
-       this(messageType, true);
-    }
-
-    // to support jurisdictions who want to bypass adding meta profile by default
-    protected BaseMessage(String messageType, boolean includeMetaProfiles) {
-        // start with a bundle
-        messageBundle = new Bundle();
-        messageBundle.setId(UUID.randomUUID().toString());
-        messageBundle.setType(Bundle.BundleType.MESSAGE);
-        messageBundle.setTimestamp(new Date());
-        messageBundle.getMeta().setLastUpdated(new Date());
-
-        // Start with a message header
-        header = new MessageHeader();
-        if (includeMetaProfiles) {
-            header.getMeta().addProfile("http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-SubmissionHeader");
-        }
-        header.setId(UUID.randomUUID().toString());
-        header.setEvent(new UriType(messageType));
-
-        // add message header source
-        MessageHeader.MessageSourceComponent source = new MessageHeader.MessageSourceComponent();
-        header.setSource(source);
-
-        // add message header destination
-        MessageHeader.MessageDestinationComponent destination = new MessageHeader.MessageDestinationComponent();
-        destination.setEndpoint(DeathRecordSubmissionMessage.MESSAGE_TYPE);
-        List<MessageHeader.MessageDestinationComponent> destinationComponents = new ArrayList<>();
-        destinationComponents.add(destination);
-        header.setDestination(destinationComponents);
-
-        // setup parameters and reference in header
-        record = new Parameters();
-        if (includeMetaProfiles) {
-            record.getMeta().addProfile("http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-MessageParameters");
-        }
-        record.setId(UUID.randomUUID().toString());
-        header.addFocus(new Reference("urn:uuid:" + record.getId()));
-
-        // add message header to bundle
-        Bundle.BundleEntryComponent headerBundleComponent = new Bundle.BundleEntryComponent();
-        headerBundleComponent.setFullUrl("urn:uuid:" + header.getId());
-        headerBundleComponent.setResource(header);
-        messageBundle.addEntry(headerBundleComponent);
-
-        // add parameters resource to bundle
-        Bundle.BundleEntryComponent parametersBundleComponent = new Bundle.BundleEntryComponent();
-        parametersBundleComponent.setFullUrl("urn:uuid:" + record.getId());
-        parametersBundleComponent.setResource(record);
-        messageBundle.addEntry(parametersBundleComponent);
     }
 
     protected void extractBusinessIdentifiers(DeathCertificateDocument from) {
@@ -208,15 +260,15 @@ public abstract class BaseMessage extends Bundle {
     }
 
     protected void setSingleStringValue(String key, String value) {
-        record.setParameter(key, (String)null);
+        messageParameters.setParameter(key, (String)null);
         if (value != null && !value.trim().isEmpty()) {
-            record.setParameter(key, value);
+            messageParameters.setParameter(key, value);
         }
     }
 
     public Integer getCertNo() {
-        if (record.hasParameter("cert_no") && record.getParameter("cert_no") instanceof IntegerType) {
-            IntegerType certNoIntegerType = (IntegerType)record.getParameter("cert_no");
+        if (messageParameters.hasParameter("cert_no") && messageParameters.getParameter("cert_no") instanceof IntegerType) {
+            IntegerType certNoIntegerType = (IntegerType) messageParameters.getParameter("cert_no");
             if (certNoIntegerType.hasValue()) {
                 return certNoIntegerType.getValue();
             } else {
@@ -229,18 +281,18 @@ public abstract class BaseMessage extends Bundle {
     }
 
     public void setCertNo(Integer value) {
-        record.setParameter("cert_no", (UnsignedIntType)null);
+        messageParameters.setParameter("cert_no", (UnsignedIntType)null);
         if (value != null) {
             if (value > 999999) {
                 throw new IllegalArgumentException("Certificate number must be a maximum of six digits");
             }
-            record.addParameter("cert_no", new UnsignedIntType(value));
+            messageParameters.addParameter("cert_no", new UnsignedIntType(value));
         }
     }
 
     public String getStateAuxiliaryId() {
-        if (record.hasParameter("state_auxiliary_id") && record.getParameter("state_auxiliary_id") instanceof StringType) {
-            StringType stateAuxiliaryIdStringType = (StringType)record.getParameter("state_auxiliary_id");
+        if (messageParameters.hasParameter("state_auxiliary_id") && messageParameters.getParameter("state_auxiliary_id") instanceof StringType) {
+            StringType stateAuxiliaryIdStringType = (StringType) messageParameters.getParameter("state_auxiliary_id");
             if (stateAuxiliaryIdStringType.hasValue()) {
                 return stateAuxiliaryIdStringType.getValue();
             } else {
@@ -257,8 +309,8 @@ public abstract class BaseMessage extends Bundle {
     }
 
     public Integer getDeathYear() {
-        if (record.hasParameter() && record.getParameter("death_year") instanceof IntegerType) {
-            IntegerType deathYearIntegerType = (IntegerType)record.getParameter("death_year");
+        if (messageParameters.hasParameter() && messageParameters.getParameter("death_year") instanceof IntegerType) {
+            IntegerType deathYearIntegerType = (IntegerType) messageParameters.getParameter("death_year");
             if (deathYearIntegerType.hasValue()) {
                 return deathYearIntegerType.getValue();
             } else {
@@ -271,18 +323,18 @@ public abstract class BaseMessage extends Bundle {
     }
 
     public void setDeathYear(Integer value) {
-        record.setParameter("death_year", (UnsignedIntType)null);
+        messageParameters.setParameter("death_year", (UnsignedIntType)null);
         if (value != null) {
             if (value < 1000 || value > 9999) {
                 throw new IllegalArgumentException("Year of death must be specified using four digits");
             }
-            record.addParameter("death_year", new UnsignedIntType(value));
+            messageParameters.addParameter("death_year", new UnsignedIntType(value));
         }
     }
 
     public String getJurisdictionId() {
-        if (record.hasParameter("jurisdiction_id") && record.getParameter("jurisdiction_id") instanceof StringType) {
-            StringType jurisdictionIdStringType = (StringType)record.getParameter("jurisdiction_id");
+        if (messageParameters.hasParameter("jurisdiction_id") && messageParameters.getParameter("jurisdiction_id") instanceof StringType) {
+            StringType jurisdictionIdStringType = (StringType) messageParameters.getParameter("jurisdiction_id");
             if (jurisdictionIdStringType.hasValue()) {
                 return jurisdictionIdStringType.getValue();
             } else {
@@ -295,7 +347,7 @@ public abstract class BaseMessage extends Bundle {
     }
 
     public void setJurisdictionId(String value) {
-        record.setParameter("jurisdiction_id", (StringType)null);
+        messageParameters.setParameter("jurisdiction_id", (StringType)null);
         if (value != null) {
             if (value.length() != 2) {
                 throw new IllegalArgumentException("Jurisdiction ID must be a two character string");
@@ -304,30 +356,27 @@ public abstract class BaseMessage extends Bundle {
         }
     }
 
-    protected Bundle getBundle() {
-        return messageBundle;
-    }
-
-    protected Bundle getMessageBundleRecord() {
-        return null; // can be overridden in some cases
-    }
-
-    protected void updateMessageBundleRecord() {
-        messageBundle.getEntry().removeIf(entry -> entry.getResource() instanceof Bundle);
-        header.setFocus(null);
-        Bundle newBundle = getMessageBundleRecord();
-        if (newBundle != null) {
-            Bundle.BundleEntryComponent newEntry = new Bundle.BundleEntryComponent();
-            newEntry.setFullUrl("urn:uuid:" + newBundle.getId());
-            newEntry.setResource(newBundle);
-            messageBundle.addEntry(newEntry);
-            header.addFocus(new Reference("urn:uuid:" + newBundle.getId()));
+    public Bundle cloneAsBundle() {
+        // All messages have resource type Bundle according to the VRDR Messaging IG
+        // so we have to reconstruct the Bundle object before outputting it
+        // otherwise the parser uses the class name as the resource type
+        Bundle bundle = new Bundle();
+        bundle.setId(getId());
+        bundle.setType(BundleType.MESSAGE);
+        bundle.setTimestamp(getTimestamp());
+        for (Bundle.BundleEntryComponent entry : getEntry()) {
+            bundle.addEntry(entry);
         }
+        return bundle;
     }
 
     public String toJson(VRDRFhirContext ctx, boolean prettyPrint) {
-        updateMessageBundleRecord();
-        return ctx.getCtx().newJsonParser().setPrettyPrint(prettyPrint).encodeResourceToString(messageBundle);
+        return ctx
+                .getCtx()
+                .newJsonParser()
+                .setPrettyPrint(prettyPrint)
+                .encodeResourceToString(
+                        cloneAsBundle());
     }
 
     public String toJson(VRDRFhirContext ctx) {
@@ -335,92 +384,58 @@ public abstract class BaseMessage extends Bundle {
     }
 
     public String toXML(VRDRFhirContext ctx, boolean prettyPrint) {
-        updateMessageBundleRecord();
-        return ctx.getCtx().newXmlParser().setPrettyPrint(prettyPrint).encodeResourceToString(messageBundle);
+        return ctx
+                .getCtx()
+                .newXmlParser()
+                .setPrettyPrint(prettyPrint)
+                .encodeResourceToString(
+                        cloneAsBundle());
     }
 
     public String toXML(VRDRFhirContext ctx) {
         return toXML(ctx, false);
     }
 
-    public static String bundleToJson(VRDRFhirContext ctx, Bundle bundle) {
-        return bundleToJson(ctx, bundle, false);
-    }
-
-    public static String bundleToJson(VRDRFhirContext ctx, Bundle bundle, boolean prettyPrint) {
-        return ctx.getCtx().newJsonParser().setPrettyPrint(prettyPrint).encodeResourceToString(bundle);
-    }
-
-    public static String bundleToXml(VRDRFhirContext ctx, Bundle bundle, boolean prettyPrint) {
-        return ctx.getCtx().newXmlParser().setPrettyPrint(prettyPrint).encodeResourceToString(bundle);
-    }
-
-    public Date getMessageTimestamp() {
-        return messageBundle.getTimestamp();
-    }
-
-    public void setMessageTimestamp(Date value) {
-        messageBundle.setTimestamp(value);
-    }
-
-    public String getMessageId() {
-        if (header != null) {
-            return header.getId();
-        } else {
-            return null;
-        }
-    }
-
-    public void setMessageId(String value) {
-        header.setId(value);
-        Bundle.BundleEntryComponent messageEntry = messageBundle.getEntry().stream().filter(entry -> entry.getResource() instanceof MessageHeader).findFirst().orElse(null);
-        if (messageEntry == null) {
-            throw new IllegalArgumentException("MessageHeader not found in message bundle");
-        }
-        messageEntry.setFullUrl("urn:uuid:" + header.getId());
-        messageEntry.setResource(header);
-    }
-
     public String getMessageType() {
-        if (header != null && header.getEvent() != null && header.getEvent() instanceof UriType) {
-            return ((UriType)header.getEvent()).getValue();
+        if (messageHeader != null && messageHeader.getEvent() != null && messageHeader.getEvent() instanceof UriType) {
+            return ((UriType) messageHeader.getEvent()).getValue();
         } else {
             return null;
         }
     }
 
     public void setMessageType(String value) {
-        header.setEvent(new UriType(value));
+        messageHeader.setEvent(new UriType(value));
     }
 
     public String getMessageSource() {
-        if (header != null && header.getSource() != null) {
-            return header.getSource().getEndpoint();
+        if (messageHeader != null && messageHeader.getSource() != null) {
+            return messageHeader.getSource().getEndpoint();
         } else {
             return null;
         }
     }
 
     public void setMessageSource(String value) {
-        if (header.getSource() == null) {
-            header.setSource(new MessageHeader.MessageSourceComponent());
+        if (messageHeader.getSource() == null) {
+            messageHeader.setSource(new MessageHeader.MessageSourceComponent());
         }
-        header.getSource().setEndpoint(value);
+        messageHeader.getSource().setEndpoint(value);
     }
 
     public String getMessageDestination() {
-        if (header != null && header.getDestination().size() > 0) {
-            return header.getDestination().get(0).getEndpoint();
+        if (messageHeader != null && messageHeader.getDestination().size() > 0) {
+            return messageHeader.getDestination().get(0).getEndpoint();
         } else {
             return null;
         }
     }
 
     public void setMessageDestination(String value) {
-        header.getDestination().clear();
+        messageHeader.getDestination().clear();
         MessageHeader.MessageDestinationComponent dest = new MessageHeader.MessageDestinationComponent();
         dest.setEndpoint(value);
-        header.getDestination().add(dest);
+        messageHeader.getDestination().add(dest);
     }
 
     public String getNCHSIdentifier() {
@@ -431,10 +446,6 @@ public abstract class BaseMessage extends Bundle {
             return null;
         }
         return String.format("%04d", deathYear) + jurisdictionId + String.format("%06d", certNo);
-    }
-
-    public Bundle getMessageBundle() {
-        return messageBundle;
     }
 
     public static String getAbsoluteFilePath(String filePath) {

--- a/src/main/java/edu/gatech/chai/VRDR/messaging/CauseOfDeathCodingMessage.java
+++ b/src/main/java/edu/gatech/chai/VRDR/messaging/CauseOfDeathCodingMessage.java
@@ -11,6 +11,7 @@ import org.hl7.fhir.r4.model.MessageHeader;
 @ResourceDef(name = "CauseOfDeathCodingMessage", profile = "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-CauseOfDeathCodingMessage")
 public class CauseOfDeathCodingMessage extends BaseMessage implements DocumentBundler<CauseOfDeathCodedContentBundle> {
 
+    // from the VRDR Messaging IG http://build.fhir.org/ig/nightingaleproject/vital_records_fhir_messaging_ig/branches/main/StructureDefinition-VRM-CauseOfDeathCodingMessage.html
     public static final String MESSAGE_TYPE = "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-CauseOfDeathCodingMessage";
 
     private CauseOfDeathCodedContentBundle causeOfDeathCodedContentBundle;

--- a/src/main/java/edu/gatech/chai/VRDR/messaging/CauseOfDeathCodingMessage.java
+++ b/src/main/java/edu/gatech/chai/VRDR/messaging/CauseOfDeathCodingMessage.java
@@ -1,12 +1,12 @@
 package edu.gatech.chai.VRDR.messaging;
 
 import ca.uhn.fhir.model.api.annotation.ResourceDef;
-import edu.gatech.chai.VRDR.messaging.util.BaseMessage;
 import edu.gatech.chai.VRDR.messaging.util.DocumentBundler;
 import edu.gatech.chai.VRDR.model.CauseOfDeathCodedContentBundle;
-import edu.gatech.chai.VRDR.model.DeathCertificateDocument;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.MessageHeader;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.ResourceType;
 
 @ResourceDef(name = "CauseOfDeathCodingMessage", profile = "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-CauseOfDeathCodingMessage")
 public class CauseOfDeathCodingMessage extends BaseMessage implements DocumentBundler<CauseOfDeathCodedContentBundle> {
@@ -22,7 +22,7 @@ public class CauseOfDeathCodingMessage extends BaseMessage implements DocumentBu
 
     public CauseOfDeathCodingMessage(Bundle messageBundle) {
         super(messageBundle);
-        updateDocumentBundle(CauseOfDeathCodedContentBundle.class, this);
+        setDocumentBundleFromMessageBundle(CauseOfDeathCodedContentBundle.class, this, messageBundle);
     }
 
     public CauseOfDeathCodedContentBundle getDocumentBundle() {
@@ -39,10 +39,11 @@ public class CauseOfDeathCodingMessage extends BaseMessage implements DocumentBu
 
     public void setCauseOfDeathCodedContentBundle(CauseOfDeathCodedContentBundle causeOfDeathCodedContentBundle) {
         this.causeOfDeathCodedContentBundle = causeOfDeathCodedContentBundle;
+        addBundleEntryAndLinkToHeader(this, messageHeader, causeOfDeathCodedContentBundle);
     }
 
     public CauseOfDeathCodingMessage(BaseMessage messageToCode) {
-        this(messageToCode == null ? null : messageToCode.getMessageId(),
+        this(messageToCode == null ? null : messageToCode.getId(),
                 messageToCode == null ? null : messageToCode.getMessageDestination(),
                 messageToCode == null ? null : messageToCode.getMessageSource());
         setCertNo(messageToCode == null ? null : messageToCode.getCertNo());
@@ -53,32 +54,28 @@ public class CauseOfDeathCodingMessage extends BaseMessage implements DocumentBu
 
     public CauseOfDeathCodingMessage(String messageId, String source, String destination) {
         super(MESSAGE_TYPE);
-        header.getSource().setEndpoint(source == null ? DeathRecordSubmissionMessage.MESSAGE_TYPE : source);
+        messageHeader.getSource().setEndpoint(source == null ? DeathRecordSubmissionMessage.MESSAGE_TYPE : source);
         setMessageDestination(destination);
         MessageHeader.MessageHeaderResponseComponent resp = new MessageHeader.MessageHeaderResponseComponent();
         resp.setIdentifier(messageId);
         resp.setCode(MessageHeader.ResponseType.OK);
-        header.setResponse(resp);
+        messageHeader.setResponse(resp);
     }
 
     public String getIGMessageType() {
         return MESSAGE_TYPE;
     }
 
-    protected Bundle getMessageBundleRecord() {
-        return causeOfDeathCodedContentBundle;
-    }
-
     public String getCodedMessageId() {
-        return header != null && header.getResponse() != null ? header.getResponse().getIdentifier() : null;
+        return messageHeader != null && messageHeader.getResponse() != null ? messageHeader.getResponse().getIdentifier() : null;
     }
 
     public void setCodedMessageId(String value) {
-        if (header.getResponse() == null) {
-            header.setResponse(new MessageHeader.MessageHeaderResponseComponent());
-            header.getResponse().setCode(MessageHeader.ResponseType.OK);
+        if (messageHeader.getResponse() == null) {
+            messageHeader.setResponse(new MessageHeader.MessageHeaderResponseComponent());
+            messageHeader.getResponse().setCode(MessageHeader.ResponseType.OK);
         }
-        header.getResponse().setIdentifier(value);
+        messageHeader.getResponse().setIdentifier(value);
     }
 
 }

--- a/src/main/java/edu/gatech/chai/VRDR/messaging/CauseOfDeathCodingUpdateMessage.java
+++ b/src/main/java/edu/gatech/chai/VRDR/messaging/CauseOfDeathCodingUpdateMessage.java
@@ -11,6 +11,7 @@ import org.hl7.fhir.r4.model.MessageHeader;
 @ResourceDef(name = "CauseOfDeathCodingUpdateMessage", profile = "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-CauseOfDeathCodingUpdateMessage")
 public class CauseOfDeathCodingUpdateMessage extends BaseMessage implements DocumentBundler<CauseOfDeathCodedContentBundle> {
 
+    // from the VRDR Messaging IG http://build.fhir.org/ig/nightingaleproject/vital_records_fhir_messaging_ig/branches/main/StructureDefinition-VRM-CauseOfDeathCodingUpdateMessage.html
     public static final String MESSAGE_TYPE = "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-CauseOfDeathCodingUpdateMessage";
 
     private CauseOfDeathCodedContentBundle causeOfDeathCodedContentBundle;

--- a/src/main/java/edu/gatech/chai/VRDR/messaging/CauseOfDeathCodingUpdateMessage.java
+++ b/src/main/java/edu/gatech/chai/VRDR/messaging/CauseOfDeathCodingUpdateMessage.java
@@ -1,12 +1,12 @@
 package edu.gatech.chai.VRDR.messaging;
 
 import ca.uhn.fhir.model.api.annotation.ResourceDef;
-import edu.gatech.chai.VRDR.messaging.util.BaseMessage;
 import edu.gatech.chai.VRDR.messaging.util.DocumentBundler;
 import edu.gatech.chai.VRDR.model.CauseOfDeathCodedContentBundle;
-import edu.gatech.chai.VRDR.model.DeathCertificateDocument;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.MessageHeader;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.ResourceType;
 
 @ResourceDef(name = "CauseOfDeathCodingUpdateMessage", profile = "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-CauseOfDeathCodingUpdateMessage")
 public class CauseOfDeathCodingUpdateMessage extends BaseMessage implements DocumentBundler<CauseOfDeathCodedContentBundle> {
@@ -22,7 +22,7 @@ public class CauseOfDeathCodingUpdateMessage extends BaseMessage implements Docu
 
     public CauseOfDeathCodingUpdateMessage(Bundle messageBundle) {
         super(messageBundle);
-        updateDocumentBundle(CauseOfDeathCodedContentBundle.class, this);
+        setDocumentBundleFromMessageBundle(CauseOfDeathCodedContentBundle.class, this, messageBundle);
     }
 
     public CauseOfDeathCodedContentBundle getDocumentBundle() {
@@ -31,6 +31,7 @@ public class CauseOfDeathCodingUpdateMessage extends BaseMessage implements Docu
 
     public void setDocumentBundle(CauseOfDeathCodedContentBundle causeOfDeathCodedContentBundle) {
         setCauseOfDeathCodedContentBundle(causeOfDeathCodedContentBundle);
+        addBundleEntryAndLinkToHeader(this, messageHeader, causeOfDeathCodedContentBundle);
     }
 
     public CauseOfDeathCodedContentBundle getCauseOfDeathCodedContentBundle() {
@@ -42,7 +43,7 @@ public class CauseOfDeathCodingUpdateMessage extends BaseMessage implements Docu
     }
 
     public CauseOfDeathCodingUpdateMessage(BaseMessage messageToCode) {
-        this(messageToCode == null ? null : messageToCode.getMessageId(),
+        this(messageToCode == null ? null : messageToCode.getId(),
                 messageToCode == null ? null : messageToCode.getMessageDestination(),
                 messageToCode == null ? null : messageToCode.getMessageSource());
         setCertNo(messageToCode == null ? null : messageToCode.getCertNo());
@@ -53,12 +54,12 @@ public class CauseOfDeathCodingUpdateMessage extends BaseMessage implements Docu
 
     public CauseOfDeathCodingUpdateMessage(String messageId, String source, String destination) {
         super(MESSAGE_TYPE);
-        header.getSource().setEndpoint(source == null ? DeathRecordSubmissionMessage.MESSAGE_TYPE : source);
+        messageHeader.getSource().setEndpoint(source == null ? DeathRecordSubmissionMessage.MESSAGE_TYPE : source);
         setMessageDestination(destination);
         MessageHeader.MessageHeaderResponseComponent resp = new MessageHeader.MessageHeaderResponseComponent();
         resp.setIdentifier(messageId);
         resp.setCode(MessageHeader.ResponseType.OK);
-        header.setResponse(resp);
+        messageHeader.setResponse(resp);
     }
 
     public String getIGMessageType() {
@@ -69,20 +70,16 @@ public class CauseOfDeathCodingUpdateMessage extends BaseMessage implements Docu
         this(messageId, destination, DeathRecordSubmissionMessage.MESSAGE_TYPE);
     }
 
-    protected Bundle getMessageBundleRecord() {
-        return causeOfDeathCodedContentBundle;
-    }
-
     public String getCodedMessageId() {
-        return header != null && header.getResponse() != null ? header.getResponse().getIdentifier() : null;
+        return messageHeader != null && messageHeader.getResponse() != null ? messageHeader.getResponse().getIdentifier() : null;
     }
 
     public void setCodedMessageId(String value) {
-        if (header.getResponse() == null) {
-            header.setResponse(new MessageHeader.MessageHeaderResponseComponent());
-            header.getResponse().setCode(MessageHeader.ResponseType.OK);
+        if (messageHeader.getResponse() == null) {
+            messageHeader.setResponse(new MessageHeader.MessageHeaderResponseComponent());
+            messageHeader.getResponse().setCode(MessageHeader.ResponseType.OK);
         }
-        header.getResponse().setIdentifier(value);
+        messageHeader.getResponse().setIdentifier(value);
     }
 
 }

--- a/src/main/java/edu/gatech/chai/VRDR/messaging/DeathRecordAliasMessage.java
+++ b/src/main/java/edu/gatech/chai/VRDR/messaging/DeathRecordAliasMessage.java
@@ -1,7 +1,6 @@
 package edu.gatech.chai.VRDR.messaging;
 
 import ca.uhn.fhir.model.api.annotation.ResourceDef;
-import edu.gatech.chai.VRDR.messaging.util.BaseMessage;
 import edu.gatech.chai.VRDR.model.DeathCertificateDocument;
 import edu.gatech.chai.VRDR.model.Decedent;
 import edu.gatech.chai.VRDR.model.DecedentFather;
@@ -70,7 +69,7 @@ public class DeathRecordAliasMessage extends BaseMessage {
     }
 
     public String getAliasDecedentFirstName() {
-        Type type = record.getParameter("alias_decedent_first_name");
+        Type type = messageParameters.getParameter("alias_decedent_first_name");
         if (type instanceof StringType) {
             return ((StringType) type).getValue();
         }
@@ -82,7 +81,7 @@ public class DeathRecordAliasMessage extends BaseMessage {
     }
 
     public String getAliasDecedentLastName() {
-        Type type = record.getParameter("alias_decedent_last_name");
+        Type type = messageParameters.getParameter("alias_decedent_last_name");
         if (type instanceof StringType) {
             return ((StringType) type).getValue();
         }
@@ -94,7 +93,7 @@ public class DeathRecordAliasMessage extends BaseMessage {
     }
 
     public String getAliasDecedentMiddleName() {
-        Type type = record.getParameter("alias_decedent_middle_name");
+        Type type = messageParameters.getParameter("alias_decedent_middle_name");
         if (type instanceof StringType) {
             return ((StringType) type).getValue();
         }
@@ -106,7 +105,7 @@ public class DeathRecordAliasMessage extends BaseMessage {
     }
 
     public String getAliasDecedentNameSuffix() {
-        Type type = record.getParameter("alias_decedent_name_suffix");
+        Type type = messageParameters.getParameter("alias_decedent_name_suffix");
         if (type instanceof StringType) {
             return ((StringType) type).getValue();
         }
@@ -118,7 +117,7 @@ public class DeathRecordAliasMessage extends BaseMessage {
     }
 
     public String getAliasFatherSurname() {
-        Type type = record.getParameter("alias_father_surname");
+        Type type = messageParameters.getParameter("alias_father_surname");
         if (type instanceof StringType) {
             return ((StringType) type).getValue();
         }
@@ -130,7 +129,7 @@ public class DeathRecordAliasMessage extends BaseMessage {
     }
 
     public String getAliasSocialSecurityNumber() {
-        Type type = record.getParameter("alias_social_security_number");
+        Type type = messageParameters.getParameter("alias_social_security_number");
         if (type instanceof StringType) {
             return ((StringType) type).getValue();
         }

--- a/src/main/java/edu/gatech/chai/VRDR/messaging/DeathRecordSubmissionMessage.java
+++ b/src/main/java/edu/gatech/chai/VRDR/messaging/DeathRecordSubmissionMessage.java
@@ -1,10 +1,13 @@
 package edu.gatech.chai.VRDR.messaging;
 
 import ca.uhn.fhir.model.api.annotation.ResourceDef;
-import edu.gatech.chai.VRDR.messaging.util.BaseMessage;
 import edu.gatech.chai.VRDR.messaging.util.DocumentBundler;
 import edu.gatech.chai.VRDR.model.DeathCertificateDocument;
+import edu.gatech.chai.VRDR.model.DemographicCodedContentBundle;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.MessageHeader;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.ResourceType;
 
 @ResourceDef(name = "DeathRecordSubmissionMessage", profile = "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-DeathRecordSubmissionMessage")
 public class DeathRecordSubmissionMessage extends BaseMessage implements DocumentBundler<DeathCertificateDocument> {
@@ -26,7 +29,7 @@ public class DeathRecordSubmissionMessage extends BaseMessage implements Documen
 
     public DeathRecordSubmissionMessage(Bundle messageBundle) {
         super(messageBundle);
-        updateDocumentBundle(DeathCertificateDocument.class, this);
+        setDocumentBundleFromMessageBundle(DeathCertificateDocument.class, this, messageBundle);
     }
 
     public DeathCertificateDocument getDocumentBundle() {
@@ -47,17 +50,9 @@ public class DeathRecordSubmissionMessage extends BaseMessage implements Documen
 
     public void setDeathRecord(DeathCertificateDocument deathRecord) {
         this.deathRecord = deathRecord;
-        updateMessageBundleRecord();
+        addBundleEntryAndLinkToHeader(this, messageHeader, deathRecord);
     }
 
-    protected Bundle getMessageBundleRecord() {
-        if (deathRecord != null) {
-            return deathRecord;
-        }
-        else {
-            return null;
-        }
-    }
 
     public String getDeathLocationJurisdiction() {
         return getDeathLocationJurisdiction(deathRecord);

--- a/src/main/java/edu/gatech/chai/VRDR/messaging/DeathRecordUpdateMessage.java
+++ b/src/main/java/edu/gatech/chai/VRDR/messaging/DeathRecordUpdateMessage.java
@@ -48,6 +48,7 @@ public class DeathRecordUpdateMessage extends BaseMessage implements DocumentBun
 
     public void setDeathRecord(DeathCertificateDocument deathRecord) {
         this.deathRecord = deathRecord;
+        extractBusinessIdentifiers(deathRecord);
         updateMessageBundleRecord();
     }
 

--- a/src/main/java/edu/gatech/chai/VRDR/messaging/DeathRecordUpdateMessage.java
+++ b/src/main/java/edu/gatech/chai/VRDR/messaging/DeathRecordUpdateMessage.java
@@ -1,10 +1,10 @@
 package edu.gatech.chai.VRDR.messaging;
 
 import ca.uhn.fhir.model.api.annotation.ResourceDef;
-import edu.gatech.chai.VRDR.messaging.util.BaseMessage;
 import edu.gatech.chai.VRDR.messaging.util.DocumentBundler;
 import edu.gatech.chai.VRDR.model.DeathCertificateDocument;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.ResourceType;
 
 @ResourceDef(name = "DeathRecordUpdateMessage", profile = "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-DeathRecordUpdateMessage")
 public class DeathRecordUpdateMessage extends BaseMessage implements DocumentBundler<DeathCertificateDocument> {
@@ -26,7 +26,7 @@ public class DeathRecordUpdateMessage extends BaseMessage implements DocumentBun
 
     public DeathRecordUpdateMessage(Bundle messageBundle) {
         super(messageBundle);
-        updateDocumentBundle(DeathCertificateDocument.class, this);
+        setDocumentBundleFromMessageBundle(DeathCertificateDocument.class, this, messageBundle);
     }
 
 
@@ -49,16 +49,7 @@ public class DeathRecordUpdateMessage extends BaseMessage implements DocumentBun
     public void setDeathRecord(DeathCertificateDocument deathRecord) {
         this.deathRecord = deathRecord;
         extractBusinessIdentifiers(deathRecord);
-        updateMessageBundleRecord();
-    }
-
-    protected Bundle getMessageBundleRecord() {
-        if (deathRecord != null) {
-            return deathRecord;
-        }
-        else {
-            return null;
-        }
+        addBundleEntryAndLinkToHeader(this, messageHeader, deathRecord);
     }
 
     public String getDeathLocationJurisdiction() {

--- a/src/main/java/edu/gatech/chai/VRDR/messaging/DeathRecordVoidMessage.java
+++ b/src/main/java/edu/gatech/chai/VRDR/messaging/DeathRecordVoidMessage.java
@@ -1,11 +1,11 @@
 package edu.gatech.chai.VRDR.messaging;
 
 import ca.uhn.fhir.model.api.annotation.ResourceDef;
-import edu.gatech.chai.VRDR.messaging.util.BaseMessage;
 import edu.gatech.chai.VRDR.model.DeathCertificateDocument;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.MessageHeader;
+import org.hl7.fhir.r4.model.ResourceType;
 
 @ResourceDef(name = "DeathRecordVoidMessage", profile = "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-DeathRecordVoidMessage")
 public class DeathRecordVoidMessage extends BaseMessage {
@@ -26,7 +26,7 @@ public class DeathRecordVoidMessage extends BaseMessage {
     }
 
     public DeathRecordVoidMessage(BaseMessage messageToVoid) {
-        this(messageToVoid == null ? null : messageToVoid.getMessageId(),
+        this(messageToVoid == null ? null : messageToVoid.getId(),
                 messageToVoid == null ? null : messageToVoid.getMessageDestination(),
                 messageToVoid == null ? null : messageToVoid.getMessageSource());
         setCertNo(messageToVoid == null ? null : messageToVoid.getCertNo());
@@ -37,12 +37,12 @@ public class DeathRecordVoidMessage extends BaseMessage {
 
     public DeathRecordVoidMessage(String messageId, String source, String destination) {
         super(MESSAGE_TYPE);
-        header.getSource().setEndpoint(source == null ? DeathRecordSubmissionMessage.MESSAGE_TYPE : source);
+        messageHeader.getSource().setEndpoint(source == null ? DeathRecordSubmissionMessage.MESSAGE_TYPE : source);
         setMessageDestination(destination);
         MessageHeader.MessageHeaderResponseComponent resp = new MessageHeader.MessageHeaderResponseComponent();
         resp.setIdentifier(messageId);
         resp.setCode(MessageHeader.ResponseType.OK);
-        header.setResponse(resp);
+        messageHeader.setResponse(resp);
     }
 
     public String getIGMessageType() {
@@ -50,16 +50,16 @@ public class DeathRecordVoidMessage extends BaseMessage {
     }
 
     public Integer getBlockCount() {
-        if (record == null) {
+        if (messageParameters == null) {
             return null;
         }
-        if (!record.hasParameter("block_count")) {
+        if (!messageParameters.hasParameter("block_count")) {
             return null;
         }
-        if (!(record.getParameter("block_count") instanceof IntegerType)) {
+        if (!(messageParameters.getParameter("block_count") instanceof IntegerType)) {
             return null;
         }
-        IntegerType blockCountType = (IntegerType) record.getParameter("block_count");
+        IntegerType blockCountType = (IntegerType) messageParameters.getParameter("block_count");
         if (blockCountType == null) {
             return null;
         }
@@ -68,11 +68,16 @@ public class DeathRecordVoidMessage extends BaseMessage {
 
     public void setBlockCount(Integer value) {
         if (value != null && value > 1) {
-            record.setParameter("block_count", new IntegerType(value));
+            messageParameters.setParameter("block_count", new IntegerType(value));
         }
         else {
-            record.setParameter("block_count", (IntegerType)null);
+            messageParameters.setParameter("block_count", (IntegerType)null);
         }
+    }
+
+    @Override
+    public ResourceType getResourceType() {
+        return ResourceType.Bundle;
     }
 
 }

--- a/src/main/java/edu/gatech/chai/VRDR/messaging/DemographicsCodingMessage.java
+++ b/src/main/java/edu/gatech/chai/VRDR/messaging/DemographicsCodingMessage.java
@@ -11,6 +11,7 @@ import org.hl7.fhir.r4.model.MessageHeader;
 @ResourceDef(name = "DemographicsCodingMessage", profile = "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-DemographicsCodingMessage")
 public class DemographicsCodingMessage extends BaseMessage implements DocumentBundler<DemographicCodedContentBundle> {
 
+    // this comes from the VRDR Messaging IG http://build.fhir.org/ig/nightingaleproject/vital_records_fhir_messaging_ig/branches/main/StructureDefinition-VRM-DemographicsCodingMessage.html
     public static final String MESSAGE_TYPE = "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-DemographicsCodingMessage";
 
     private DemographicCodedContentBundle demographicCodedContentBundle;

--- a/src/main/java/edu/gatech/chai/VRDR/messaging/DemographicsCodingMessage.java
+++ b/src/main/java/edu/gatech/chai/VRDR/messaging/DemographicsCodingMessage.java
@@ -1,12 +1,13 @@
 package edu.gatech.chai.VRDR.messaging;
 
 import ca.uhn.fhir.model.api.annotation.ResourceDef;
-import edu.gatech.chai.VRDR.messaging.util.BaseMessage;
 import edu.gatech.chai.VRDR.messaging.util.DocumentBundler;
-import edu.gatech.chai.VRDR.model.DeathCertificateDocument;
+import edu.gatech.chai.VRDR.model.CauseOfDeathCodedContentBundle;
 import edu.gatech.chai.VRDR.model.DemographicCodedContentBundle;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.MessageHeader;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.ResourceType;
 
 @ResourceDef(name = "DemographicsCodingMessage", profile = "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-DemographicsCodingMessage")
 public class DemographicsCodingMessage extends BaseMessage implements DocumentBundler<DemographicCodedContentBundle> {
@@ -22,7 +23,7 @@ public class DemographicsCodingMessage extends BaseMessage implements DocumentBu
 
     public DemographicsCodingMessage(Bundle messageBundle) {
         super(messageBundle);
-        updateDocumentBundle(DemographicCodedContentBundle.class, this);
+        setDocumentBundleFromMessageBundle(DemographicCodedContentBundle.class, this, messageBundle);
     }
 
     public DemographicCodedContentBundle getDocumentBundle() {
@@ -39,10 +40,11 @@ public class DemographicsCodingMessage extends BaseMessage implements DocumentBu
 
     public void setDemographicCodedContentBundle(DemographicCodedContentBundle demographicCodedContentBundle) {
         this.demographicCodedContentBundle = demographicCodedContentBundle;
+        addBundleEntryAndLinkToHeader(this, messageHeader, demographicCodedContentBundle);
     }
 
     public DemographicsCodingMessage(BaseMessage messageToCode) {
-        this(messageToCode == null ? null : messageToCode.getMessageId(),
+        this(messageToCode == null ? null : messageToCode.getId(),
                 messageToCode == null ? null : messageToCode.getMessageDestination(),
                 messageToCode == null ? null : messageToCode.getMessageSource());
         setCertNo(messageToCode == null ? null : messageToCode.getCertNo());
@@ -53,33 +55,28 @@ public class DemographicsCodingMessage extends BaseMessage implements DocumentBu
 
     public DemographicsCodingMessage(String messageId, String source, String destination) {
         super(MESSAGE_TYPE);
-        header.getSource().setEndpoint(source == null ? DeathRecordSubmissionMessage.MESSAGE_TYPE : source);
+        messageHeader.getSource().setEndpoint(source == null ? DeathRecordSubmissionMessage.MESSAGE_TYPE : source);
         setMessageDestination(destination);
         MessageHeader.MessageHeaderResponseComponent resp = new MessageHeader.MessageHeaderResponseComponent();
         resp.setIdentifier(messageId);
         resp.setCode(MessageHeader.ResponseType.OK);
-        header.setResponse(resp);
+        messageHeader.setResponse(resp);
     }
 
     public String getIGMessageType() {
         return MESSAGE_TYPE;
     }
 
-
-    protected Bundle getMessageBundleRecord() {
-        return demographicCodedContentBundle;
-    }
-
     public String getCodedMessageId() {
-        return header != null && header.getResponse() != null ? header.getResponse().getIdentifier() : null;
+        return messageHeader != null && messageHeader.getResponse() != null ? messageHeader.getResponse().getIdentifier() : null;
     }
 
     public void setCodedMessageId(String value) {
-        if (header.getResponse() == null) {
-            header.setResponse(new MessageHeader.MessageHeaderResponseComponent());
-            header.getResponse().setCode(MessageHeader.ResponseType.OK);
+        if (messageHeader.getResponse() == null) {
+            messageHeader.setResponse(new MessageHeader.MessageHeaderResponseComponent());
+            messageHeader.getResponse().setCode(MessageHeader.ResponseType.OK);
         }
-        header.getResponse().setIdentifier(value);
+        messageHeader.getResponse().setIdentifier(value);
     }
 
 }

--- a/src/main/java/edu/gatech/chai/VRDR/messaging/DemographicsCodingUpdateMessage.java
+++ b/src/main/java/edu/gatech/chai/VRDR/messaging/DemographicsCodingUpdateMessage.java
@@ -1,12 +1,12 @@
 package edu.gatech.chai.VRDR.messaging;
 
 import ca.uhn.fhir.model.api.annotation.ResourceDef;
-import edu.gatech.chai.VRDR.messaging.util.BaseMessage;
 import edu.gatech.chai.VRDR.messaging.util.DocumentBundler;
-import edu.gatech.chai.VRDR.model.DeathCertificateDocument;
 import edu.gatech.chai.VRDR.model.DemographicCodedContentBundle;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.MessageHeader;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.ResourceType;
 
 @ResourceDef(name = "DemographicsCodingUpdateMessage", profile = "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-DemographicsCodingUpdateMessage")
 public class DemographicsCodingUpdateMessage extends BaseMessage implements DocumentBundler<DemographicCodedContentBundle> {
@@ -22,11 +22,7 @@ public class DemographicsCodingUpdateMessage extends BaseMessage implements Docu
 
     public DemographicsCodingUpdateMessage(Bundle messageBundle) {
         super(messageBundle);
-        updateDocumentBundle(DemographicCodedContentBundle.class, this);
-    }
-
-    public DemographicCodedContentBundle getDocumentBundle() {
-        return getDemographicCodedContentBundle();
+        setDocumentBundleFromMessageBundle(DemographicCodedContentBundle.class, this, messageBundle);
     }
 
     public void setDocumentBundle(DemographicCodedContentBundle demographicCodedContentBundle) {
@@ -39,10 +35,11 @@ public class DemographicsCodingUpdateMessage extends BaseMessage implements Docu
 
     public void setDemographicCodedContentBundle(DemographicCodedContentBundle demographicCodedContentBundle) {
         this.demographicCodedContentBundle = demographicCodedContentBundle;
+        addBundleEntryAndLinkToHeader(this, messageHeader, demographicCodedContentBundle);
     }
 
     public DemographicsCodingUpdateMessage(BaseMessage messageToCode) {
-        this(messageToCode == null ? null : messageToCode.getMessageId(),
+        this(messageToCode == null ? null : messageToCode.getId(),
                 messageToCode == null ? null : messageToCode.getMessageDestination(),
                 messageToCode == null ? null : messageToCode.getMessageSource());
         setCertNo(messageToCode == null ? null : messageToCode.getCertNo());
@@ -53,32 +50,32 @@ public class DemographicsCodingUpdateMessage extends BaseMessage implements Docu
 
     public DemographicsCodingUpdateMessage(String messageId, String source, String destination) {
         super(MESSAGE_TYPE);
-        header.getSource().setEndpoint(source == null ? DeathRecordSubmissionMessage.MESSAGE_TYPE : source);
+        messageHeader.getSource().setEndpoint(source == null ? DeathRecordSubmissionMessage.MESSAGE_TYPE : source);
         setMessageDestination(destination);
         MessageHeader.MessageHeaderResponseComponent resp = new MessageHeader.MessageHeaderResponseComponent();
         resp.setIdentifier(messageId);
         resp.setCode(MessageHeader.ResponseType.OK);
-        header.setResponse(resp);
+        messageHeader.setResponse(resp);
     }
 
     public String getIGMessageType() {
         return MESSAGE_TYPE;
     }
 
-    protected Bundle getMessageBundleRecord() {
-        return demographicCodedContentBundle;
+    public DemographicCodedContentBundle getDocumentBundle() {
+        return getDocumentBundle();
     }
 
     public String getCodedMessageId() {
-        return header != null && header.getResponse() != null ? header.getResponse().getIdentifier() : null;
+        return messageHeader != null && messageHeader.getResponse() != null ? messageHeader.getResponse().getIdentifier() : null;
     }
 
     public void setCodedMessageId(String value) {
-        if (header.getResponse() == null) {
-            header.setResponse(new MessageHeader.MessageHeaderResponseComponent());
-            header.getResponse().setCode(MessageHeader.ResponseType.OK);
+        if (messageHeader.getResponse() == null) {
+            messageHeader.setResponse(new MessageHeader.MessageHeaderResponseComponent());
+            messageHeader.getResponse().setCode(MessageHeader.ResponseType.OK);
         }
-        header.getResponse().setIdentifier(value);
+        messageHeader.getResponse().setIdentifier(value);
     }
 
 }

--- a/src/main/java/edu/gatech/chai/VRDR/messaging/DemographicsCodingUpdateMessage.java
+++ b/src/main/java/edu/gatech/chai/VRDR/messaging/DemographicsCodingUpdateMessage.java
@@ -11,6 +11,7 @@ import org.hl7.fhir.r4.model.MessageHeader;
 @ResourceDef(name = "DemographicsCodingUpdateMessage", profile = "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-DemographicsCodingUpdateMessage")
 public class DemographicsCodingUpdateMessage extends BaseMessage implements DocumentBundler<DemographicCodedContentBundle> {
 
+    // this comes from the VRDR Messaging IG http://build.fhir.org/ig/nightingaleproject/vital_records_fhir_messaging_ig/branches/main/StructureDefinition-VRM-DemographicsCodingUpdateMessage.html
     public static final String MESSAGE_TYPE = "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-DemographicsCodingUpdateMessage";
 
     private DemographicCodedContentBundle demographicCodedContentBundle;

--- a/src/main/java/edu/gatech/chai/VRDR/messaging/StatusMessage.java
+++ b/src/main/java/edu/gatech/chai/VRDR/messaging/StatusMessage.java
@@ -1,11 +1,7 @@
 package edu.gatech.chai.VRDR.messaging;
 
 import ca.uhn.fhir.model.api.annotation.ResourceDef;
-import edu.gatech.chai.VRDR.messaging.util.BaseMessage;
-import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.MessageHeader;
-import org.hl7.fhir.r4.model.StringType;
-import org.hl7.fhir.r4.model.Type;
+import org.hl7.fhir.r4.model.*;
 
 @ResourceDef(name = "StatusMessage", profile = "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-StatusMessage")
 public class StatusMessage extends BaseMessage {
@@ -21,7 +17,7 @@ public class StatusMessage extends BaseMessage {
     }
 
     public StatusMessage(BaseMessage messageToStatus) {
-        this(messageToStatus == null ? null : messageToStatus.getMessageId(),
+        this(messageToStatus == null ? null : messageToStatus.getId(),
                 messageToStatus == null ? null : messageToStatus.getMessageSource(),
                 messageToStatus == null ? null : messageToStatus.getMessageDestination());
         setCertNo(messageToStatus == null ? null : messageToStatus.getCertNo());
@@ -37,12 +33,12 @@ public class StatusMessage extends BaseMessage {
 
     public StatusMessage(String messageId, String destination, String source) {
         super(MESSAGE_TYPE);
-        header.getSource().setEndpoint(source);
+        messageHeader.getSource().setEndpoint(source);
         setMessageDestination(destination);
         MessageHeader.MessageHeaderResponseComponent resp = new MessageHeader.MessageHeaderResponseComponent();
         resp.setIdentifier(messageId);
         resp.setCode(MessageHeader.ResponseType.OK);
-        header.setResponse(resp);
+        messageHeader.setResponse(resp);
     }
 
     public StatusMessage(String messageId, String destination) {
@@ -54,19 +50,19 @@ public class StatusMessage extends BaseMessage {
     }
 
     public String getStatusedMessageId() {
-        return header != null && header.getResponse() != null ? header.getResponse().getIdentifier() : null;
+        return messageHeader != null && messageHeader.getResponse() != null ? messageHeader.getResponse().getIdentifier() : null;
     }
 
     public void setStatusedMessageId(String value) {
-        if (header.getResponse() == null) {
-            header.setResponse(new MessageHeader.MessageHeaderResponseComponent());
-            header.getResponse().setCode(MessageHeader.ResponseType.OK);
+        if (messageHeader.getResponse() == null) {
+            messageHeader.setResponse(new MessageHeader.MessageHeaderResponseComponent());
+            messageHeader.getResponse().setCode(MessageHeader.ResponseType.OK);
         }
-        header.getResponse().setIdentifier(value);
+        messageHeader.getResponse().setIdentifier(value);
     }
 
     public String getStatus() {
-        Type type = record.getParameter("status");
+        Type type = messageParameters.getParameter("status");
         if (type instanceof StringType) {
             return ((StringType) type).getValue();
         }
@@ -76,4 +72,5 @@ public class StatusMessage extends BaseMessage {
     public void setStatus(String status) {
         setSingleStringValue("status", status);
     }
+
 }

--- a/src/main/java/edu/gatech/chai/VRDR/messaging/util/BaseMessage.java
+++ b/src/main/java/edu/gatech/chai/VRDR/messaging/util/BaseMessage.java
@@ -71,6 +71,11 @@ public abstract class BaseMessage extends Bundle {
     }
 
     protected BaseMessage(String messageType) {
+       this(messageType, true);
+    }
+
+    // to support jurisdictions who want to bypass adding meta profile by default
+    protected BaseMessage(String messageType, boolean includeMetaProfiles) {
         // start with a bundle
         messageBundle = new Bundle();
         messageBundle.setId(UUID.randomUUID().toString());
@@ -80,7 +85,9 @@ public abstract class BaseMessage extends Bundle {
 
         // Start with a message header
         header = new MessageHeader();
-        header.getMeta().addProfile("http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-SubmissionHeader");
+        if (includeMetaProfiles) {
+            header.getMeta().addProfile("http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-SubmissionHeader");
+        }
         header.setId(UUID.randomUUID().toString());
         header.setEvent(new UriType(messageType));
 
@@ -97,7 +104,9 @@ public abstract class BaseMessage extends Bundle {
 
         // setup parameters and reference in header
         record = new Parameters();
-        record.getMeta().addProfile("http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-MessageParameters");
+        if (includeMetaProfiles) {
+            record.getMeta().addProfile("http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-MessageParameters");
+        }
         record.setId(UUID.randomUUID().toString());
         header.addFocus(new Reference("urn:uuid:" + record.getId()));
 
@@ -220,12 +229,12 @@ public abstract class BaseMessage extends Bundle {
     }
 
     public void setCertNo(Integer value) {
-        record.setParameter("cert_no", (IntegerType)null);
+        record.setParameter("cert_no", (UnsignedIntType)null);
         if (value != null) {
             if (value > 999999) {
                 throw new IllegalArgumentException("Certificate number must be a maximum of six digits");
             }
-            record.addParameter("cert_no", new IntegerType(value));
+            record.addParameter("cert_no", new UnsignedIntType(value));
         }
     }
 
@@ -262,12 +271,12 @@ public abstract class BaseMessage extends Bundle {
     }
 
     public void setDeathYear(Integer value) {
-        record.setParameter("death_year", (IntegerType)null);
+        record.setParameter("death_year", (UnsignedIntType)null);
         if (value != null) {
             if (value < 1000 || value > 9999) {
                 throw new IllegalArgumentException("Year of death must be specified using four digits");
             }
-            record.addParameter("death_year", new IntegerType(value));
+            record.addParameter("death_year", new UnsignedIntType(value));
         }
     }
 

--- a/src/main/java/edu/gatech/chai/VRDR/messaging/util/MessageParseException.java
+++ b/src/main/java/edu/gatech/chai/VRDR/messaging/util/MessageParseException.java
@@ -1,5 +1,6 @@
 package edu.gatech.chai.VRDR.messaging.util;
 
+import edu.gatech.chai.VRDR.messaging.BaseMessage;
 import edu.gatech.chai.VRDR.messaging.ExtractionErrorMessage;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.OperationOutcome;
@@ -14,7 +15,7 @@ public class MessageParseException extends IllegalArgumentException {
 
     public MessageParseException(String errorMessage, Bundle sourceBundle) {
         super(errorMessage);
-        this.sourceMessage = new UnknownMessage(sourceBundle, true, true, true);
+        this.sourceMessage = new UnknownMessage(sourceBundle);
     }
 
     public MessageParseException(String errorMessage, BaseMessage sourceMessage) {

--- a/src/main/java/edu/gatech/chai/VRDR/messaging/util/UnknownMessage.java
+++ b/src/main/java/edu/gatech/chai/VRDR/messaging/util/UnknownMessage.java
@@ -1,5 +1,6 @@
 package edu.gatech.chai.VRDR.messaging.util;
 
+import edu.gatech.chai.VRDR.messaging.BaseMessage;
 import org.hl7.fhir.r4.model.Bundle;
 
 // a message whose type is unknown, such as during a parsing error, but we still want to inspect and return info on the message
@@ -12,11 +13,7 @@ public class UnknownMessage extends BaseMessage {
     }
 
     public UnknownMessage(Bundle messageBundle) {
-        super(messageBundle);
-    }
-
-    public UnknownMessage(Bundle messageBundle, boolean ignoreMissingEntries, boolean ignoreBundleType, boolean ignoreEventType) {
-        super(messageBundle, ignoreMissingEntries, ignoreBundleType, ignoreEventType);
+        super(messageBundle, true);
     }
 
     public String getIGMessageType() {

--- a/src/main/java/edu/gatech/chai/VRDR/model/BirthRecordIdentifier.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/BirthRecordIdentifier.java
@@ -10,7 +10,7 @@ import ca.uhn.fhir.model.api.annotation.ResourceDef;
 import edu.gatech.chai.VRDR.model.util.BirthRecordIdentifierUtil;
 import edu.gatech.chai.VRDR.model.util.CommonUtil;
 
-@ResourceDef(name = "Observation", profile = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-BirthRecordIdentifier")
+@ResourceDef(name = "Observation", profile = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-birth-record-identifier")
 public class BirthRecordIdentifier extends Observation {
 
 	public BirthRecordIdentifier() {

--- a/src/main/java/edu/gatech/chai/VRDR/model/CauseOfDeathCodedContentBundle.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/CauseOfDeathCodedContentBundle.java
@@ -8,7 +8,7 @@ import edu.gatech.chai.VRDR.model.util.CommonUtil;
 
 import java.util.List;
 
-@ResourceDef(name = "Bundle", profile = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-coded-content-bundle")
+@ResourceDef(name = "Bundle", profile = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-coded-bundle")
 public class CauseOfDeathCodedContentBundle extends Bundle {
 
 	/**

--- a/src/main/java/edu/gatech/chai/VRDR/model/DeathCertificate.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/DeathCertificate.java
@@ -66,7 +66,7 @@ public class DeathCertificate extends Composition {
 		component.setParty(new Reference(resource.getId()));
 		addAttester(component);
 		// author is required from VRDR IG http://hl7.org/fhir/us/vrdr/StructureDefinition-vrdr-death-certificate.html
-		addAuthor(castToReference(resource));
+		addAuthor(new Reference(resource.getId()));
 	}
 
 	public void addEvent(DeathCertificationProcedure resource) {
@@ -93,8 +93,9 @@ public class DeathCertificate extends Composition {
 			addResource(resource, DeathCertificateUtil.codedContentSectionCode);
 		}
 		else {
-			System.out.println("resource not added successfuly Id: " + resource.getId());
-			System.out.println("resourceType: " + resource.getClass().getCanonicalName());
+			throw new IllegalArgumentException("Resource not added successfully. " +
+				"id: "	+ resource.getId() +
+				"resourceType: " + resource.getClass().getCanonicalName());
 		}
 	}
 	

--- a/src/main/java/edu/gatech/chai/VRDR/model/DeathCertificate.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/DeathCertificate.java
@@ -26,6 +26,7 @@ public class DeathCertificate extends Composition {
 		CommonUtil.initResource(this);
 		setType(DeathCertificateUtil.typeFixedValue);
 		setStatus(DeathCertificateUtil.status);
+		setTitle(DeathCertificateUtil.title);
 		setDate(new Date());
 	}
 	
@@ -64,6 +65,8 @@ public class DeathCertificate extends Composition {
 		component.setTime(time);
 		component.setParty(new Reference(resource.getId()));
 		addAttester(component);
+		// author is required from VRDR IG http://hl7.org/fhir/us/vrdr/StructureDefinition-vrdr-death-certificate.html
+		addAuthor(castToReference(resource));
 	}
 
 	public void addEvent(DeathCertificationProcedure resource) {

--- a/src/main/java/edu/gatech/chai/VRDR/model/DeathCertificateDocument.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/DeathCertificateDocument.java
@@ -44,7 +44,7 @@ public class DeathCertificateDocument extends Bundle {
 	public void addResource(Resource resource) {
 		DeathCertificate deathCertificate = getDeathCertificate().get(0);
 		deathCertificate.addResource(resource);
-		this.addEntry(new BundleEntryComponent().setResource(resource));
+		this.addEntry(new BundleEntryComponent().setResource(resource)); 
 	}
 	
 	//Helper Accessor methods

--- a/src/main/java/edu/gatech/chai/VRDR/model/DeathLocation.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/DeathLocation.java
@@ -13,22 +13,14 @@ public class DeathLocation extends Location {
 	public DeathLocation() {
 		super();
 		CommonUtil.initResource(this);
+		// type is required and values are fixed as per VRDR IG http://hl7.org/fhir/us/vrdr/StructureDefinition-vrdr-death-location.html
+		addType(DeathLocationUtil.typeCode);
 	}
-	public DeathLocation(String name, String description, CodeableConcept type, Address address) {
+	public DeathLocation(String name, String description, Address address) {
 		this();
 		setName(name);
 		setDescription(description);
-		addType(type);
 		setAddress(address);
 	}
-	
-	public DeathLocation(String name, String description, String type, Address address) {
-		this();
-		CodeableConcept typeCC = CommonUtil.findConceptFromCollectionUsingSimpleString(type, DeathLocationUtil.placeOfDeathTypeSet);
-		setName(name);
-		setDescription(description);
-		addType(typeCC);
-		setAddress(address);
-	}
-	
+
 }

--- a/src/main/java/edu/gatech/chai/VRDR/model/DecedentAge.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/DecedentAge.java
@@ -18,30 +18,28 @@ public class DecedentAge extends Observation {
 
 	public DecedentAge() {
 		super();
+		CommonUtil.initResource(this);
+		// required fields and fixed values by VRDR IG http://hl7.org/fhir/us/vrdr/StructureDefinition-vrdr-decedent-age.html
+		super.setStatus(DecedentAgeUtil.status);
+		super.setCode(DecedentAgeUtil.code);
 	}
 	
 	public DecedentAge(Reference subject) {
-		super();
-		CommonUtil.initResource(this);
-		super.setStatus(DecedentAgeUtil.status);
-		super.setCode(DecedentAgeUtil.code);
+		this();
 		super.setSubject(subject);
 	}
-	
-	public DecedentAge setDataAbsentReason(String dataAbsentReason) {
-		super.setDataAbsentReason(CommonUtil.findConceptFromCollectionUsingSimpleString(dataAbsentReason, CommonUtil.dataAbsentReasonConceptSet));
-		return this;
-	}
-	
+
 	public DecedentAge(Quantity quantity) {
-		super();
-		CommonUtil.initResource(this);
-		super.setStatus(DecedentAgeUtil.status);
-		super.setCode(DecedentAgeUtil.code);
+		this();
 		if(quantity.getCode() == null || !DecedentAgeUtil.values.contains(quantity.getCode())) {
 			throw new FHIRException("DecedentAge: Quantity expects a Code of:"+
 					DecedentAgeUtil.values);
 		}
 		super.setValue(quantity);
+	}
+
+	public DecedentAge setDataAbsentReason(String dataAbsentReason) {
+		super.setDataAbsentReason(CommonUtil.findConceptFromCollectionUsingSimpleString(dataAbsentReason, CommonUtil.dataAbsentReasonConceptSet));
+		return this;
 	}
 }

--- a/src/main/java/edu/gatech/chai/VRDR/model/DecedentDispositionMethod.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/DecedentDispositionMethod.java
@@ -7,7 +7,7 @@ import ca.uhn.fhir.model.api.annotation.ResourceDef;
 import edu.gatech.chai.VRDR.model.util.CommonUtil;
 import edu.gatech.chai.VRDR.model.util.DecedentDispositionMethodUtil;
 
-@ResourceDef(name = "Observation", profile = "http://hl7.org/fhir/us/vrdr/vrdr-decedent-disposition-method")
+@ResourceDef(name = "Observation", profile = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-disposition-method")
 public class DecedentDispositionMethod extends Observation {
 	public DecedentDispositionMethod() {
 		super();

--- a/src/main/java/edu/gatech/chai/VRDR/model/DecedentFather.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/DecedentFather.java
@@ -6,7 +6,7 @@ import ca.uhn.fhir.model.api.annotation.ResourceDef;
 import edu.gatech.chai.VRDR.model.util.CommonUtil;
 import edu.gatech.chai.VRDR.model.util.DecedentFatherUtil;
 
-@ResourceDef(name = "RelatedPerson", profile = "http://hl7.org/fhir/us/vrdr/vrdr-decedent-father")
+@ResourceDef(name = "RelatedPerson", profile = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-father")
 public class DecedentFather extends RelatedPerson {
 	public DecedentFather() {
 		super();

--- a/src/main/java/edu/gatech/chai/VRDR/model/DecedentMilitaryService.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/DecedentMilitaryService.java
@@ -11,7 +11,7 @@ import edu.gatech.chai.VRDR.model.util.CommonUtil;
 import edu.gatech.chai.VRDR.model.util.DecedentMilitaryServiceUtil;
 import edu.gatech.chai.VRDR.model.util.DecedentUsualWorkUtil;
 
-@ResourceDef(name = "Observation", profile = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-Military-Service")
+@ResourceDef(name = "Observation", profile = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-military-service")
 public class DecedentMilitaryService extends Observation {
 	public DecedentMilitaryService() {
 		super();

--- a/src/main/java/edu/gatech/chai/VRDR/model/DecedentMother.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/DecedentMother.java
@@ -6,7 +6,7 @@ import ca.uhn.fhir.model.api.annotation.ResourceDef;
 import edu.gatech.chai.VRDR.model.util.CommonUtil;
 import edu.gatech.chai.VRDR.model.util.DecedentMotherUtil;
 
-@ResourceDef(name = "RelatedPerson", profile = "http://hl7.org/fhir/us/vrdr/vrdr-decedent-mother")
+@ResourceDef(name = "RelatedPerson", profile = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-mother")
 public class DecedentMother extends RelatedPerson {
 	public DecedentMother() {
 		super();

--- a/src/main/java/edu/gatech/chai/VRDR/model/DecedentSpouse.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/DecedentSpouse.java
@@ -6,7 +6,7 @@ import ca.uhn.fhir.model.api.annotation.ResourceDef;
 import edu.gatech.chai.VRDR.model.util.CommonUtil;
 import edu.gatech.chai.VRDR.model.util.DecedentSpouseUtil;
 
-@ResourceDef(name = "RelatedPerson", profile = "http://hl7.org/fhir/us/vrdr/vrdr-decedent-spouse")
+@ResourceDef(name = "RelatedPerson", profile = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-spouse")
 public class DecedentSpouse extends RelatedPerson {
 	public DecedentSpouse() {
 		super();

--- a/src/main/java/edu/gatech/chai/VRDR/model/DemographicCodedContentBundle.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/DemographicCodedContentBundle.java
@@ -5,7 +5,7 @@ import edu.gatech.chai.VRDR.model.util.CommonUtil;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Identifier;
 
-@ResourceDef(name = "Bundle", profile = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-demographic-coded-content-bundle")
+@ResourceDef(name = "Bundle", profile = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-demographic-coded-bundle")
 public class DemographicCodedContentBundle extends Bundle {
 
 	/**

--- a/src/main/java/edu/gatech/chai/VRDR/model/EmergingIssues.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/EmergingIssues.java
@@ -1,4 +1,6 @@
-package edu.gatech.chai.VRDR.model;
+  
+
+     package edu.gatech.chai.VRDR.model;
 
 import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.CodeableConcept;
@@ -32,14 +34,16 @@ public class EmergingIssues extends Observation {
 	 */
 	private static final long serialVersionUID = -2672514795721353562L;
 
-	//Redefining value and effective as min and max = 0 to disbar the fields.
+	/* Even though these fields are not allowed as per VRDR IG http://hl7.org/fhir/us/vrdr/StructureDefinition-vrdr-emerging-issues.html
+	 * they are not redefined due to issues this causes in some clients.
 	@Child(name = "value", type = {Quantity.class, CodeableConcept.class, StringType.class, BooleanType.class, IntegerType.class, Range.class, Ratio.class, SampledData.class, TimeType.class, DateTimeType.class, Period.class}, order=2, min=0, max=0, modifier=false, summary=true)
     @Description(shortDefinition="Actual component result", formalDefinition="The information determined as a result of making the observation, if the information has a simple value." )
     protected Type value;
 	
-	@Child(name = "effective", type = {DateTimeType.class, Period.class, Timing.class, InstantType.class}, order=9, min=0, max=1, modifier=false, summary=true)
+    @Child(name = "effective", type = {DateTimeType.class, Period.class, Timing.class, InstantType.class}, order=9, min=0, max=1, modifier=false, summary=true)
     @Description(shortDefinition="Clinically relevant time/time-period for observation", formalDefinition="The time or time-period the observed value is asserted as being true. For biological subjects - e.g. human patients - this is usually called the \"physiologically relevant time\". This is usually either the time of the procedure or of specimen collection, but very often the source of the date/time is not known, only the date/time itself." )
     protected Type effective;
+    */
 	
 	public EmergingIssues() {
 		super();

--- a/src/main/java/edu/gatech/chai/VRDR/model/InputRaceAndEthnicity.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/InputRaceAndEthnicity.java
@@ -13,6 +13,8 @@ import edu.gatech.chai.VRDR.model.util.InputRaceAndEthnicityUtil;
 @ResourceDef(name = "Observation", profile = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-input-race-and-ethnicity")
 public class InputRaceAndEthnicity extends Observation {
 	public InputRaceAndEthnicity() {
+		super();
+		CommonUtil.initResource(this);
 		this.setCode(InputRaceAndEthnicityUtil.code);
 	}
 	
@@ -73,16 +75,19 @@ public class InputRaceAndEthnicity extends Observation {
 	public void addComponent(String codeName, BooleanType value) {
 		ObservationComponentComponent occ = addComponentCommon(codeName);
 		occ.setValue(value);
+		this.addComponent(occ);
 	}
 	
 	public void addComponent(String codeName, CodeableConcept value) {
 		ObservationComponentComponent occ = addComponentCommon(codeName);
 		occ.setValue(value);
+		this.addComponent(occ);
 	}
 	
 	public void addComponent(String codeName, StringType value) {
 		ObservationComponentComponent occ = addComponentCommon(codeName);
 		occ.setValue(value);
+		this.addComponent(occ);
 	}
 	
 	private ObservationComponentComponent addComponentCommon(String codeName) {

--- a/src/main/java/edu/gatech/chai/VRDR/model/TobaccoUseContributedToDeath.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/TobaccoUseContributedToDeath.java
@@ -7,7 +7,7 @@ import ca.uhn.fhir.model.api.annotation.ResourceDef;
 import edu.gatech.chai.VRDR.model.util.CommonUtil;
 import edu.gatech.chai.VRDR.model.util.TobaccoUseContributedToDeathUtil;
 
-@ResourceDef(name = "Observation", profile = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-Tobacco-Use-Contributed-To-Death")
+@ResourceDef(name = "Observation", profile = "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-tobacco-use-contributed-to-death")
 public class TobaccoUseContributedToDeath extends Observation {
 	public TobaccoUseContributedToDeath() {
 		super();

--- a/src/main/java/edu/gatech/chai/VRDR/model/util/AddressUtil.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/util/AddressUtil.java
@@ -11,7 +11,7 @@ import org.hl7.fhir.r4.model.PositiveIntType;
 import org.hl7.fhir.r4.model.StringType;
 
 public class AddressUtil {
-	public static String withinCityLimitsIndicatorUrl = "http://hl7.org/fhir/us/vrdr/StructureDefinition/Within-City-Limits-Indicator";
+	public static String withinCityLimitsIndicatorUrl = "http://hl7.org/fhir/us/vrdr/StructureDefinition/WithinCityLimitsIndicator";
 	public static String locationJurisdictionIdUrl = "http://hl7.org/fhir/us/vrdr/StructureDefinition/Location-Jurisdiction-Id";
 	public static String cityCodeUrl = "http://hl7.org/fhir/us/vrdr/StructureDefinition/CityCode";
 	public static String districtCodeUrl = "http://hl7.org/fhir/us/vrdr/StructureDefinition/DistrictCode";

--- a/src/main/java/edu/gatech/chai/VRDR/model/util/BirthRecordIdentifierUtil.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/util/BirthRecordIdentifierUtil.java
@@ -7,11 +7,11 @@ import org.hl7.fhir.r4.model.Observation.ObservationStatus;
 
 public class BirthRecordIdentifierUtil {
 	public static final CodeableConcept code = new CodeableConcept()
-			.addCoding(new Coding("http://terminology.hl7.org/CodeSystem/v2-0203", "BR", "Birth registry number"));
+			.addCoding(new Coding(CommonUtil.identifierTypeHL7System, "BR", "Birth registry number"));
 	public static final CodeableConcept componentBirthStateCode = new CodeableConcept()
 			.addCoding(new Coding(CommonUtil.loincSystemUrl, "21842-0", "Birthplace"));
 	public static final String componentBirthStateValueCodeableConceptSystem = "urn:iso:std:iso:3166:-2";
 	public static final CodeableConcept componentBirthYearCode = new CodeableConcept()
-			.addCoding(new Coding(CommonUtil.loincSystemUrl, "80904-6", "Birth Year"));
+			.addCoding(new Coding(CommonUtil.loincSystemUrl, "80904-6", "Birth year"));
 	public static final ObservationStatus status = Observation.ObservationStatus.FINAL;
 }

--- a/src/main/java/edu/gatech/chai/VRDR/model/util/BuildDCD.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/util/BuildDCD.java
@@ -46,7 +46,7 @@ public class BuildDCD {
     	Address decedentsHome = new Address().addLine("1808 Stroop Hill Road").setCity("Atlanta")
 		.setState("GA").setPostalCode("30303").setCountry("USA").setUse(AddressUse.HOME);
     	Extension withinCityLimits = new Extension();
-		withinCityLimits.setUrl(DecedentUtil.addressWithinCityLimitsIndicatorExtensionURL);
+		withinCityLimits.setUrl(AddressUtil.withinCityLimitsIndicatorUrl);
 		withinCityLimits.setValue(new BooleanType(true));
 		decedentsHome.addExtension(withinCityLimits);
     	decedent.setGender(AdministrativeGender.MALE);
@@ -135,14 +135,13 @@ public class BuildDCD {
     	deathDate.setSubject(decedentReference);
     	contents.add(deathDate);
     	//DeathLocation
-    	CodeableConcept deathLocationType = new CodeableConcept().addCoding(new Coding("http://hl7.org/fhir/v3/RoleCode","wi","Wing"));
     	Address hospitalAddress = new Address().addLine("80 Jesse Hill Jr Dr SE").setCity("Atlanta")
     			.setState("GA").setPostalCode("30303").setCountry("USA").setUse(AddressUse.WORK);
     	//Address Utils to add extensions to addresses
     	AddressUtil.addCityCode(11122, hospitalAddress);
     	AddressUtil.addDistrictCode(22233, hospitalAddress);
     	AddressUtil.addStateJurisdiction("GA", hospitalAddress); //Do not need to do this if the jurisdiction matches the state
-    	DeathLocation deathLocation = new DeathLocation("Grady Hospital","Grady Hospital of Atlanta",deathLocationType,hospitalAddress);
+    	DeathLocation deathLocation = new DeathLocation("Grady Hospital", "Grady Hospital of Atlanta", hospitalAddress);
     	initResourceForTesting(deathLocation);
     	contents.add(deathLocation);
     	//DecedentAge
@@ -243,7 +242,7 @@ public class BuildDCD {
     	Address decedentsHome = new Address().addLine("1808 Stroop Hill Road").setCity("Atlanta")
 		.setState("GA").setPostalCode("30303").setCountry("USA").setUse(AddressUse.HOME);
     	Extension withinCityLimits = new Extension();
-		withinCityLimits.setUrl(DecedentUtil.addressWithinCityLimitsIndicatorExtensionURL);
+		withinCityLimits.setUrl(AddressUtil.withinCityLimitsIndicatorUrl);
 		withinCityLimits.setValue(new BooleanType(true));
 		decedentsHome.addExtension(withinCityLimits);
     	decedent.setGender(AdministrativeGender.MALE);

--- a/src/main/java/edu/gatech/chai/VRDR/model/util/CauseOfDeathConditionUtil.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/util/CauseOfDeathConditionUtil.java
@@ -9,7 +9,6 @@ import org.hl7.fhir.r4.model.Coding;
 public class CauseOfDeathConditionUtil {
 	public static final String conditionalClinicalSystemUrl = "http://terminology.hl7.org/CodeSystem/condition-clinical";
 	public static final String verificationSystemUrl = "http://terminology.hl7.org/CodeSystem/condition-ver-status";
-	public static final String categorySystemUrl = "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category";
 	public static final HashSet<CodeableConcept> conditionClinicalStatusSet = new HashSet<>(Arrays.asList(
 			new CodeableConcept().addCoding(new Coding(conditionalClinicalSystemUrl,"active","Active")),
 			new CodeableConcept().addCoding(new Coding(conditionalClinicalSystemUrl,"recurrence","Recurrence")),
@@ -24,10 +23,6 @@ public class CauseOfDeathConditionUtil {
 			new CodeableConcept().addCoding(new Coding(verificationSystemUrl,"confirmed","Confirmed")),
 			new CodeableConcept().addCoding(new Coding(verificationSystemUrl,"refuted","Refuted")),
 			new CodeableConcept().addCoding(new Coding(verificationSystemUrl,"entered-in-error","Entered-in-Error"))));
-	/*public static final HashSet<CodeableConcept> categorySet = new HashSet<>(Arrays.asList(
-			new CodeableConcept().addCoding(new Coding(categorySystemUrl,"problem-list-item","Problem List Item")),
-			new CodeableConcept().addCoding(new Coding(categorySystemUrl,"encounter-diagnosis","Encounter Diagnosis")),
-			new CodeableConcept().addCoding(new Coding(categorySystemUrl,"health-concern","Health Concern"))));*/
 	public static final CodeableConcept code = new CodeableConcept().addCoding(new Coding(CommonUtil.loincSystemUrl, "69453-9", "Cause of death [US Standard Certificate of Death]"));
 	public static final CodeableConcept intervalComponentCode = new CodeableConcept().addCoding(new Coding(CommonUtil.loincSystemUrl, "69440-6", "Disease onset to death interval"));
 

--- a/src/main/java/edu/gatech/chai/VRDR/model/util/CertifierUtil.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/util/CertifierUtil.java
@@ -2,4 +2,5 @@ package edu.gatech.chai.VRDR.model.util;
 
 public class CertifierUtil {
 	public static final String qualificationSystemUrl = "http://hl7.org/fhir/v2/0360/2.7";
+	public static final String npiSystemUrl = "http://hl7.org/fhir/sid/us-npi";
 }

--- a/src/main/java/edu/gatech/chai/VRDR/model/util/CommonUtil.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/util/CommonUtil.java
@@ -16,7 +16,8 @@ import edu.gatech.chai.VRDR.model.DeathCertificate;
 import edu.gatech.chai.VRDR.model.DeathCertificateDocument;
 
 public class CommonUtil {
-	public static final String basicBooleanHL7System = "http://hl7.org/CodeSystem/v2-0136";
+	public static final String identifierTypeHL7System = "http://terminology.hl7.org/CodeSystem/v2-0203";
+	public static final String basicBooleanHL7System = "http://terminology.hl7.org/CodeSystem/v2-0136";
 	public static final String yesNoNASystemOID = "urn:oid:2.16.840.1.113883.12.136";
 	public static final String nullFlavorSystemOID = "urn:oid:2.16.840.1.113883.5.1008";
 	public static final String nullFlavorHL7System = "http://terminology.hl7.org/CodeSystem/v3-NullFlavor";
@@ -40,8 +41,13 @@ public class CommonUtil {
 	public static CodeableConcept noCode = new CodeableConcept().addCoding(new Coding(basicBooleanHL7System,"N","No"));
 	public static CodeableConcept yesCode = new CodeableConcept().addCoding(new Coding(basicBooleanHL7System,"Y","Yes"));
 	public static CodeableConcept unknownCode = new CodeableConcept().addCoding(new Coding(nullFlavorHL7System,"UNK","unknown"));
-	public static CodeableConcept otherCode = new CodeableConcept().addCoding(new Coding(nullFlavorHL7System,"OTH","other"));
-	public static CodeableConcept notApplicableCode = new CodeableConcept().addCoding(new Coding(nullFlavorHL7System,"NA","not applicable"));
+	public static CodeableConcept otherCode = new CodeableConcept().addCoding(new Coding(nullFlavorHL7System, "OTH", "other"));
+	public static CodeableConcept notApplicableCode = new CodeableConcept().addCoding(new Coding(nullFlavorHL7System, "NA", "not applicable"));	public static CodeableConcept askuCode = new CodeableConcept().addCoding(new Coding(nullFlavorHL7System,"ASKU","asked but unknown"));
+	public static Coding otherCoding = new Coding(nullFlavorHL7System, "OTH", "other");
+	public static Coding notApplicableCoding = new Coding(nullFlavorHL7System, "NA", "not applicable");
+	public static Coding noCoding = new Coding(basicBooleanHL7System,"N","No");
+	public static Coding yesCoding = new Coding(basicBooleanHL7System,"Y","Yes");
+	public static Coding unknownCoding = new Coding(nullFlavorHL7System,"UNK","unknown");
 	public static CodeableConcept notAskedCode = new CodeableConcept().addCoding(new Coding(nullFlavorHL7System,"NASK","not asked"));
 	public static final String deathReportingIdentifierTypeSystem = "urn:oid:2.16.840.1.114222.4.11.7382";
 	public static CodeableConcept deathCertificateIdCode = new CodeableConcept().addCoding(new Coding(deathReportingIdentifierTypeSystem,"DC","Death Certificate Id"));
@@ -172,7 +178,7 @@ public class CommonUtil {
 	}
 
 	public static void initResource(Resource resource) {
-		//setUUID(resource);
+		setUUID(resource);
 	}
 	
 	public static void setUUID(Resource resource) {

--- a/src/main/java/edu/gatech/chai/VRDR/model/util/DeathCertificateUtil.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/util/DeathCertificateUtil.java
@@ -3,6 +3,8 @@ package edu.gatech.chai.VRDR.model.util;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Composition;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.Composition.CompositionStatus;
 
 import edu.gatech.chai.VRDR.model.ActivityAtTimeOfDeath;
@@ -43,6 +45,7 @@ import edu.gatech.chai.VRDR.model.TobaccoUseContributedToDeath;
 
 public class DeathCertificateUtil {
 	public static final CompositionStatus status = CompositionStatus.FINAL;  
+	public static final String title = "Death Certificate";
 	public static final CodeableConcept typeFixedValue = new CodeableConcept()
 			.addCoding(new Coding(CommonUtil.loincSystemUrl,"64297-5","Death certificate"));
 	public static final Composition.CompositionAttestationMode attesterMode = Composition.CompositionAttestationMode.LEGAL;
@@ -54,7 +57,7 @@ public class DeathCertificateUtil {
 	public static final CodeableConcept deathInvestigationSectionCode = new CodeableConcept()
 			.addCoding(new Coding(vrdrDocumentSectionUrl,"DeathInvestigation",""));
 	public static final CodeableConcept deathCertificationSectionCode = new CodeableConcept()
-			.addCoding(new Coding(vrdrDocumentSectionUrl,"DeathCertificationProcedure",""));
+			.addCoding(new Coding(vrdrDocumentSectionUrl,"DeathCertification",""));
 	public static final CodeableConcept decedentDispositionSectionCode = new CodeableConcept()
 			.addCoding(new Coding(vrdrDocumentSectionUrl,"DecedentDisposition",""));
 	public static final CodeableConcept codedContentSectionCode = new CodeableConcept()
@@ -74,4 +77,12 @@ public class DeathCertificateUtil {
 			CodedRaceAndEthnicity.class,EntityAxisCauseOfDeath.class,RecordAxisCauseOfDeath.class,PlaceOfInjury.class,
 			CodingStatusValues.class};
 	
+	public static final String filingFormatExtensionUrl = "http://hl7.org/fhir/us/vrdr/StructureDefinition/FilingFormat";
+	public static final String filingFormatExtensionCodeSystem = "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-filing-format-cs";
+	public static final CodeableConcept electronicFilingFormat = new CodeableConcept()
+			.addCoding(new Coding().setSystem(filingFormatExtensionCodeSystem).setCode("electronic").setDisplay("Electronic"));
+	public static final CodeableConcept mixedFilingFormat = new CodeableConcept()
+			.addCoding(new Coding().setSystem(filingFormatExtensionCodeSystem).setCode("mixed").setDisplay("Mixed"));
+	public static final CodeableConcept paperFilingFormat = new CodeableConcept()
+			.addCoding(new Coding().setSystem(filingFormatExtensionCodeSystem).setCode("paper").setDisplay("Paper"));
 }

--- a/src/main/java/edu/gatech/chai/VRDR/model/util/DeathLocationUtil.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/util/DeathLocationUtil.java
@@ -7,16 +7,21 @@ import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 
 public class DeathLocationUtil {
+	public static final CodeableConcept VALUE_HOSPITAL = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"16983000","Death in hospital"));
+	public static final CodeableConcept VALUE_EMERGENCY_OUTPATIENT = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"450391000124102","Death in hospital-based emergency department or outpatient department (event)"));
+	public static final CodeableConcept VALUE_HOME = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"440081000124100","Death in home"));
+	public static final CodeableConcept VALUE_HOSPICE = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"440071000124103","Death in hospice"));
+	public static final CodeableConcept VALUE_ARRIVAL = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"63238001","Dead on arrival at hospital"));
+	public static final CodeableConcept VALUE_NURSINGHOME = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"450381000124100","Death in nursing home or long term care facility (event)"));
 	public static final HashSet<CodeableConcept> placeOfDeathTypeSet = new HashSet<>(Arrays.asList(
-			new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"16983000","Death in hospital")),
-			new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"450391000124102","Death in hospital-based emergency department or outpatient department (event)")),
-			new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"440081000124100","Death in home")),
-			new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"440071000124103","Death in hospice")),
-			new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"63238001","Dead on arrival at hospital")),
-			new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"16983000","Death in hospital")),
-			new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"450391000124102","Death in hospital-based emergency department or outpatient department (event)")),
-			new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"450381000124100","Death in nursing home or long term care facility (event)")),
-			new CodeableConcept().addCoding(new Coding(CommonUtil.nullFlavorHL7System,"OTH","Other")),
-			new CodeableConcept().addCoding(new Coding(CommonUtil.nullFlavorHL7System,"UNK","Unknown"))
-			));
+			VALUE_HOSPITAL,
+			VALUE_EMERGENCY_OUTPATIENT,
+			VALUE_HOME,
+			VALUE_HOSPICE,
+			VALUE_ARRIVAL,
+			VALUE_NURSINGHOME,
+			CommonUtil.otherCode,
+			CommonUtil.unknownCode
+	));
+	public static CodeableConcept typeCode = new CodeableConcept(new Coding().setSystem("http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs").setCode("death").setDisplay("death location"));
 }

--- a/src/main/java/edu/gatech/chai/VRDR/model/util/DecedentDispositionMethodUtil.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/util/DecedentDispositionMethodUtil.java
@@ -17,7 +17,7 @@ public class DecedentDispositionMethodUtil {
 	public static final CodeableConcept VALUE_BURIALCODE = new CodeableConcept().addCoding(new Coding().setCode("449971000124106").setSystem(CommonUtil.snomedSystemUrl).setDisplay("Burial"));
 	public static final CodeableConcept VALUE_CREMATIONCODE = new CodeableConcept().addCoding(new Coding().setCode("449961000124104").setSystem(CommonUtil.snomedSystemUrl).setDisplay("Cremation"));
 	public static final CodeableConcept VALUE_ENTOMBEDCODE = new CodeableConcept().addCoding(new Coding().setCode("449931000124108").setSystem(CommonUtil.snomedSystemUrl).setDisplay("Entombment"));
-	public static final CodeableConcept VALUE_REMOVALFROMSTATECODE = new CodeableConcept().addCoding(new Coding().setCode("449931000124108").setSystem(CommonUtil.snomedSystemUrl).setDisplay("Removal from state"));
+	public static final CodeableConcept VALUE_REMOVALFROMSTATECODE = new CodeableConcept().addCoding(new Coding().setCode("449941000124103").setSystem(CommonUtil.snomedSystemUrl).setDisplay("Removal from state"));
 	public static final CodeableConcept VALUE_HOSPITALDISPOSITIONCODE = new CodeableConcept().addCoding(new Coding().setCode("373066001").setSystem(CommonUtil.snomedSystemUrl).setDisplay("Hospital Disposition"));
 	public static List<CodeableConcept> valueCodesetList = new ArrayList<CodeableConcept>(Arrays.asList(VALUE_DONATEDCODE,VALUE_BURIALCODE,VALUE_CREMATIONCODE,VALUE_ENTOMBEDCODE,VALUE_REMOVALFROMSTATECODE,VALUE_HOSPITALDISPOSITIONCODE));
 }

--- a/src/main/java/edu/gatech/chai/VRDR/model/util/DecedentEducationLevelUtil.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/util/DecedentEducationLevelUtil.java
@@ -14,23 +14,24 @@ public class DecedentEducationLevelUtil {
 	public static final String codeValueSystem = "urn:oid:2.16.840.1.114222.4.5.274";
 	private static final String educationLevelV3SystemUrl = "http://terminology.hl7.org/CodeSystem/v3-EducationLevel";
 	private static final String educationLevelV2SystemUrl = "http://terminology.hl7.org/CodeSystem/v2-0360";
-	public static final CodeableConcept VALUE_8THGRADE = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"PHC1448", "8th grade or less"));
-	public static final CodeableConcept VALUE_12THGRADE = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"PHC1449", "9th through 12th grade; no diploma"));
-	public static final CodeableConcept VALUE_HIGHSCHOOL = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"PHC1450", "High School Graduate or GED Completed"));
-	public static final CodeableConcept VALUE_SOMECOLLEGE = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"PHC1451", "Some college credit, but not degree"));
-	public static final CodeableConcept VALUE_ASSOCIATE = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"PHC1452", "Associate Degree"));
-	public static final CodeableConcept VALUE_BACHELORS = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"PHC1453", "Bachelor's Degree"));
-	public static final CodeableConcept VALUE_MASTERS = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"PHC1454", "Master's Degree"));
-	public static final CodeableConcept VALUE_DOCTORATE = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"PHC1455", "Doctorate Degree or Professional Degree"));
+	public static final CodeableConcept VALUE_8THGRADE = new CodeableConcept().addCoding(new Coding(educationLevelV3SystemUrl,"ELEM","Elementary School"));
+	public static final CodeableConcept VALUE_12THGRADE = new CodeableConcept().addCoding(new Coding(educationLevelV3SystemUrl,"SEC","Some secondary or high school education"));
+	public static final CodeableConcept VALUE_HIGHSCHOOL = new CodeableConcept().addCoding(new Coding(educationLevelV3SystemUrl,"HS","High School or secondary school degree complete"));
+	public static final CodeableConcept VALUE_SOMECOLLEGE = new CodeableConcept().addCoding(new Coding(educationLevelV3SystemUrl,"SCOL","Some College education"));
+	public static final CodeableConcept VALUE_ASSOCIATE = new CodeableConcept().addCoding(new Coding(educationLevelV2SystemUrl,"AA","Associate's or technical degree complete"));
+	public static final CodeableConcept VALUE_BACHELORS = new CodeableConcept().addCoding(new Coding(educationLevelV2SystemUrl,"BA","Bachelor's degree"));
+	public static final CodeableConcept VALUE_MASTERS = new CodeableConcept().addCoding(new Coding(educationLevelV2SystemUrl,"MA","Master's degree"));
+	public static final CodeableConcept VALUE_DOCTORATE = new CodeableConcept().addCoding(new Coding(educationLevelV3SystemUrl,"POSTG","Doctoral or post graduate education"));
 	
 	public static final HashSet<CodeableConcept> valueSet = new HashSet<CodeableConcept>(Arrays.asList(
-			new CodeableConcept().addCoding(new Coding(educationLevelV3SystemUrl,"ELEM","Elementary School")),
-			new CodeableConcept().addCoding(new Coding(educationLevelV3SystemUrl,"SEC","Some secondary or high school education")),
-			new CodeableConcept().addCoding(new Coding(educationLevelV3SystemUrl,"HS","High School or secondary school degree complete")),
-			new CodeableConcept().addCoding(new Coding(educationLevelV3SystemUrl,"SCOL","Some College education")),
-			new CodeableConcept().addCoding(new Coding(educationLevelV2SystemUrl,"AA","Associate's or technical degree complete")),
-			new CodeableConcept().addCoding(new Coding(educationLevelV2SystemUrl,"BA","Bachelor's degree")),
-			new CodeableConcept().addCoding(new Coding(educationLevelV2SystemUrl,"MA","Master's degree")),
-			new CodeableConcept().addCoding(new Coding(educationLevelV3SystemUrl,"POSTG","Doctoral or post graduate education")),
-			new CodeableConcept().addCoding(new Coding(CommonUtil.nullFlavorHL7System,"UNK","Unknown"))));
+			VALUE_8THGRADE,
+			VALUE_12THGRADE,
+			VALUE_HIGHSCHOOL,
+			VALUE_SOMECOLLEGE,
+			VALUE_ASSOCIATE,
+			VALUE_BACHELORS,
+			VALUE_MASTERS,
+			VALUE_DOCTORATE,
+			CommonUtil.unknownCode
+	));
 }

--- a/src/main/java/edu/gatech/chai/VRDR/model/util/DecedentPregnancyStatusUtil.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/util/DecedentPregnancyStatusUtil.java
@@ -14,11 +14,19 @@ public class DecedentPregnancyStatusUtil {
 			.addCoding(new Coding().setSystem(CommonUtil.loincSystemUrl).setCode("69442-2")
 					.setDisplay("Timing of recent pregnancy in relation to death"));
 	public static final String codeValueSystem = "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-pregnancy-status-cs";
-	public static final CodeableConcept VALUE_NOCODE = new CodeableConcept().addCoding(new Coding().setCode("1").setSystem(CommonUtil.snomedSystemUrl).setDisplay("Not pregnant within past year"));
-	public static final CodeableConcept VALUE_YESCODE = new CodeableConcept().addCoding(new Coding().setCode("2").setSystem(CommonUtil.snomedSystemUrl).setDisplay("Pregnant at the time of death"));
-	public static final CodeableConcept VALUE_42DAYSCODE = new CodeableConcept().addCoding(new Coding().setCode("3").setSystem(CommonUtil.snomedSystemUrl).setDisplay("Not pregnant, but pregnant within 42 days of death"));
-	public static final CodeableConcept VALUE_1YEARCODE = new CodeableConcept().addCoding(new Coding().setCode("4").setSystem(CommonUtil.snomedSystemUrl).setDisplay("Not pregnant, but pregnant 43 days to 1 year before death"));
-	public static final CodeableConcept VALUE_UNKNOWNCODE = new CodeableConcept().addCoding(new Coding().setCode("9").setSystem(CommonUtil.snomedSystemUrl).setDisplay("Unknown if pregnant within the past year"));
+	public static final CodeableConcept VALUE_NOCODE = new CodeableConcept().addCoding(new Coding(codeValueSystem, "1", "Not pregnant within the past year"));
+	public static final CodeableConcept VALUE_YESCODE = new CodeableConcept().addCoding(new Coding(codeValueSystem, "2", "Pregnant at time of death"));
+	public static final CodeableConcept VALUE_42DAYSCODE = new CodeableConcept().addCoding(new Coding(codeValueSystem, "3", "Not pregnant, but pregnant within 42 days of death"));
+	public static final CodeableConcept VALUE_1YEARCODE = new CodeableConcept().addCoding(new Coding(codeValueSystem, "4", "Not pregnant, but pregnant 43 days to 1 year before death"));
+	public static final CodeableConcept VALUE_NOTREPORTEDCODE =new CodeableConcept().addCoding(new Coding(codeValueSystem, "7", "Not reported on certificate"));
+	public static final CodeableConcept VALUE_UNKNOWNCODE =new CodeableConcept().addCoding(new Coding(codeValueSystem, "9", "Unknown if pregnant within the past year"));
 	public static final HashSet<CodeableConcept> valueSet = new HashSet<>(Arrays.asList(
-			VALUE_NOCODE,VALUE_YESCODE,VALUE_42DAYSCODE,VALUE_1YEARCODE,VALUE_UNKNOWNCODE,CommonUtil.notApplicableCode));
+			VALUE_NOCODE,
+			VALUE_YESCODE,
+			VALUE_42DAYSCODE,
+			VALUE_1YEARCODE,
+			VALUE_NOTREPORTEDCODE,
+			VALUE_UNKNOWNCODE,
+			CommonUtil.notApplicableCode
+	));
 }

--- a/src/main/java/edu/gatech/chai/VRDR/model/util/DecedentUtil.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/util/DecedentUtil.java
@@ -65,7 +65,6 @@ public class DecedentUtil {
 		"HispanicLiteral");
 	public static final List<String> hispanicCodedNVSSSet = Arrays.asList("HispanicMexican", "HispanicPuertoRican",
 			"HispanicOther", "HispanicCuban");
-
 	public static Set<CodeableConcept> sexAtDeathSet = new HashSet<CodeableConcept>(Arrays.asList(
 			VALUE_MALE,
 			VALUE_FEMALE,

--- a/src/main/java/edu/gatech/chai/VRDR/model/util/DecedentUtil.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/util/DecedentUtil.java
@@ -19,19 +19,28 @@ public class DecedentUtil {
 	public static final String birthSexValueSetURL = "http://hl7.org/fhir/us/core/ValueSet/us-core-birthsex";
 	public static final String birthPlaceExtensionURL = "http://hl7.org/fhir/StructureDefinition/patient-birthPlace";
 	public static final String maritalStatusURL = "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus";
-	public static final String administrativeGenderURL = " http://hl7.org/fhir/administrative-gender";
-	public static final String addressWithinCityLimitsIndicatorExtensionURL = "http://hl7.org/fhir/us/vrdr/StructureDefinition/Within-City-Limits-Indicator";
+	public static final String administrativeGenderURL = "http://hl7.org/fhir/administrative-gender";
 	public static final CodeableConcept identifierTypeFixedValue = new CodeableConcept()
-			.addCoding(new Coding().setCode("SB").setDisplay("Social Beneficiary Identifier"));
+			.addCoding(new Coding().setSystem(CommonUtil.identifierTypeHL7System).setCode("SB").setDisplay("Social Beneficiary Identifier"));
 	public static final String identifierSystem = "http://hl7.org/fhir/sid/us-ssn";
 	
+	public static final String birthsexExtensionUrl = "http://hl7.org/fhir/us/vrdr/StructureDefinition/NVSS-SexAtDeath";
+	public static final String birthsexCodeSystem = "http://hl7.org/fhir/administrative-gender";
+	public static final CodeableConcept VALUE_MALE = new CodeableConcept().addCoding(new Coding(birthsexCodeSystem,"male","Male"));
+	public static final CodeableConcept VALUE_FEMALE = new CodeableConcept().addCoding(new Coding(birthsexCodeSystem,"female","Female"));
+	public static final CodeableConcept VALUE_DIVORCED = new CodeableConcept().addCoding(new Coding(maritalStatusURL,"D","Divorced"));
+	public static final CodeableConcept VALUE_SEPARATED = new CodeableConcept().addCoding(new Coding(maritalStatusURL,"L","Legally Separated"));
+	public static final CodeableConcept VALUE_MARRIED = new CodeableConcept().addCoding(new Coding(maritalStatusURL,"M","Married"));
+	public static final CodeableConcept VALUE_NEVERMARRIED = new CodeableConcept().addCoding(new Coding(maritalStatusURL,"S","Never Married"));
+	public static final CodeableConcept VALUE_WIDOWED = new CodeableConcept().addCoding(new Coding(maritalStatusURL,"W","Widowed"));
 	public static final HashSet<CodeableConcept> maritalStatusSet = new HashSet<>(Arrays.asList(
-			new CodeableConcept().addCoding(new Coding(maritalStatusURL,"M","Married")),
-			new CodeableConcept().addCoding(new Coding(maritalStatusURL,"W","Widowed")),
-			new CodeableConcept().addCoding(new Coding(maritalStatusURL,"D","Divorced")),
-			new CodeableConcept().addCoding(new Coding(maritalStatusURL,"S","Never Married")),
-			new CodeableConcept().addCoding(new Coding(maritalStatusURL,"L","Legally Separated")),
-			CommonUtil.unknownCode));
+			VALUE_DIVORCED,
+			VALUE_SEPARATED,
+			VALUE_MARRIED,
+			VALUE_NEVERMARRIED,
+			VALUE_WIDOWED,
+			CommonUtil.unknownCode
+	));
 
 	public static final List<String> raceBooleanNVSSSet = Arrays.asList("White", "BlackOrAfricanAmerican",
 			"AmericanIndianOrAlaskaNative", "AsianIndian", "Chinese", "Filipino", "Japanese", "Korean", "Vietnamese",
@@ -56,11 +65,12 @@ public class DecedentUtil {
 		"HispanicLiteral");
 	public static final List<String> hispanicCodedNVSSSet = Arrays.asList("HispanicMexican", "HispanicPuertoRican",
 			"HispanicOther", "HispanicCuban");
-	
+
 	public static Set<CodeableConcept> sexAtDeathSet = new HashSet<CodeableConcept>(Arrays.asList(
-			new CodeableConcept().addCoding(new Coding(administrativeGenderURL,"Male","Male")),
-			new CodeableConcept().addCoding(new Coding(administrativeGenderURL,"Female","Female")),
-			new CodeableConcept().addCoding(new Coding(administrativeGenderURL,"Unknown","Unknown"))
-			));
+			VALUE_MALE,
+			VALUE_FEMALE,
+			CommonUtil.unknownCode
+	));
+
 	public static Set<CodeableConcept> spouseAliveSet = CommonUtil.yesNoUnknownSet;	
 }

--- a/src/main/java/edu/gatech/chai/VRDR/model/util/DecedentUtil.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/util/DecedentUtil.java
@@ -41,7 +41,6 @@ public class DecedentUtil {
 			VALUE_WIDOWED,
 			CommonUtil.unknownCode
 	));
-
 	public static final List<String> raceBooleanNVSSSet = Arrays.asList("White", "BlackOrAfricanAmerican",
 			"AmericanIndianOrAlaskaNative", "AsianIndian", "Chinese", "Filipino", "Japanese", "Korean", "Vietnamese",
 			"OtherAsian", "NativeHawaiian", "GuamanianOrChamorro", "Samoan","OtherPacificIslander","OtherRace",

--- a/src/main/java/edu/gatech/chai/VRDR/model/util/FuneralHomeUtil.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/util/FuneralHomeUtil.java
@@ -4,6 +4,10 @@ import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 
 public class FuneralHomeUtil {
+	// fixed value as per VRDR IG http://hl7.org/fhir/us/vrdr/StructureDefinition-vrdr-funeral-home.html
+	// and http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-organization-type-cs
 	public static final CodeableConcept type = new CodeableConcept()
-			.addCoding(new Coding().setSystem("http://terminology.hl7.org/CodeSystem/organization-type").setCode("bus").setDisplay("Non-Healthcare Business or Corporation"));
+			.addCoding(new Coding().setSystem("http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-organization-type-cs")
+					.setCode("funeralhome")
+					.setDisplay("Funeral Home"));
 }

--- a/src/main/java/edu/gatech/chai/VRDR/model/util/InputRaceAndEthnicityUtil.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/util/InputRaceAndEthnicityUtil.java
@@ -8,10 +8,13 @@ import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 
 public class InputRaceAndEthnicityUtil {
-	public static final String codeAndComponentSystemUrl = "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs";
-    public static final String hispanicCodingSystemUrl= "http://terminology.hl7.org/CodeSystem/v2-0136";
 
-	public static final CodeableConcept code = new CodeableConcept().addCoding(new Coding(codeAndComponentSystemUrl, "inputraceandethnicity", "Race and Ethnicity Data submitted by Jurisdictions to NCHS"));
+    public static final String codeAndComponentSystemUrl = "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs";
+
+    public static final CodeableConcept code = new CodeableConcept().addCoding(new Coding(codeAndComponentSystemUrl, "inputraceandethnicity", "Race and Ethnicity Data submitted by Jurisdictions to NCHS"));
+
+    public static final String hispanicCodingSystemUrl= "http://hl7.org/CodeSystem/v2-0136";
+    
 	public static Set<String> raceBooleanSystemStrings = new HashSet<String>(DecedentUtil.raceBooleanNVSSSet);
 	public static Set<String> raceLiteralSystemStrings = new HashSet<String>(DecedentUtil.raceLiteralNVSSSet);
 	public static Set<String> hispanicCodedSystemStrings = new HashSet<String>(DecedentUtil.hispanicCodedNVSSSet);

--- a/src/main/java/edu/gatech/chai/VRDR/model/util/InputRaceAndEthnicityUtil.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/util/InputRaceAndEthnicityUtil.java
@@ -8,11 +8,10 @@ import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 
 public class InputRaceAndEthnicityUtil {
-	
 	public static final String codeAndComponentSystemUrl = "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs";
     public static final String hispanicCodingSystemUrl= "http://terminology.hl7.org/CodeSystem/v2-0136";
-    
-	public static final CodeableConcept code = new CodeableConcept().addCoding(new Coding(codeAndComponentSystemUrl, "inputraceandethnicity", "Input Race and Ethnicity"));
+
+	public static final CodeableConcept code = new CodeableConcept().addCoding(new Coding(codeAndComponentSystemUrl, "inputraceandethnicity", "Race and Ethnicity Data submitted by Jurisdictions to NCHS"));
 	public static Set<String> raceBooleanSystemStrings = new HashSet<String>(DecedentUtil.raceBooleanNVSSSet);
 	public static Set<String> raceLiteralSystemStrings = new HashSet<String>(DecedentUtil.raceLiteralNVSSSet);
 	public static Set<String> hispanicCodedSystemStrings = new HashSet<String>(DecedentUtil.hispanicCodedNVSSSet);
@@ -21,4 +20,5 @@ public class InputRaceAndEthnicityUtil {
 			new CodeableConcept().addCoding(new Coding(CommonUtil.missingValueReasonUrl,"S","Sought, but unknown")),
 			new CodeableConcept().addCoding(new Coding(CommonUtil.missingValueReasonUrl,"C","Not obtainable"))
 			));
+
 }

--- a/src/main/java/edu/gatech/chai/VRDR/model/util/MannerOfDeathUtil.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/util/MannerOfDeathUtil.java
@@ -12,12 +12,12 @@ public class MannerOfDeathUtil {
 	public static final ObservationStatus status = ObservationStatus.FINAL;
 	public static final CodeableConcept code = new CodeableConcept()
 			.addCoding(new Coding(CommonUtil.loincSystemUrl, "69449-7", "Manner of death"));
-	public static final CodeableConcept VALUE_NATURAL = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"38605008","Natural death"));
-	public static final CodeableConcept VALUE_ACCIDENTAL = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"7878000","Accidental death"));
-	public static final CodeableConcept VALUE_SUICIDE = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"44301001","Suicide"));
-	public static final CodeableConcept VALUE_HOMICIDE = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"27935005","Homicide"));
-	public static final CodeableConcept VALUE_INVESTIGATION = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"185973002","Pending Investigation"));
-	public static final CodeableConcept VALUE_NBD = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"65037004","Could not be determined"));
+	public static final CodeableConcept VALUE_NATURAL = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"38605008", "Natural death"));
+	public static final CodeableConcept VALUE_ACCIDENTAL = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"7878000", "Accidental death"));
+	public static final CodeableConcept VALUE_SUICIDE = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"44301001", "Suicide"));
+	public static final CodeableConcept VALUE_HOMICIDE = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"27935005", "Homicide"));
+	public static final CodeableConcept VALUE_INVESTIGATION = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"185973002", "Patient awaiting investigation"));
+	public static final CodeableConcept VALUE_NBD = new CodeableConcept().addCoding(new Coding(CommonUtil.snomedSystemUrl,"65037004", "Death, manner undetermined"));
 	public static Set<CodeableConcept> valueCodesetList = new HashSet<CodeableConcept>(Arrays.asList(
 			VALUE_NATURAL,VALUE_ACCIDENTAL,VALUE_SUICIDE,VALUE_HOMICIDE,VALUE_INVESTIGATION,VALUE_NBD));
 }

--- a/src/main/java/edu/gatech/chai/VRDR/model/util/TobaccoUseContributedToDeathUtil.java
+++ b/src/main/java/edu/gatech/chai/VRDR/model/util/TobaccoUseContributedToDeathUtil.java
@@ -11,7 +11,7 @@ import org.hl7.fhir.r4.model.Observation.ObservationStatus;
 public class TobaccoUseContributedToDeathUtil {
 	public static final ObservationStatus status = ObservationStatus.FINAL;
 	public static final CodeableConcept code = new CodeableConcept()
-			.addCoding(new Coding().setSystem(CommonUtil.loincSystemUrl).setCode("69443-0"));
+			.addCoding(new Coding().setSystem(CommonUtil.loincSystemUrl).setCode("69443-0").setDisplay("Did tobacco use contribute to death"));
 	public static final String codeValueSystem = "urn:oid:2.16.840.1.114222.4.5.274";
 	public static final CodeableConcept VALUE_YESCODE = new CodeableConcept().addCoding(new Coding().setCode("373066001").setSystem(CommonUtil.snomedSystemUrl).setDisplay("Yes"));
 	public static final CodeableConcept VALUE_NOCODE = new CodeableConcept().addCoding(new Coding().setCode("373067005").setSystem(CommonUtil.snomedSystemUrl).setDisplay("No"));

--- a/src/test/java/edu/gatech/VRDR/AppTest.java
+++ b/src/test/java/edu/gatech/VRDR/AppTest.java
@@ -47,8 +47,7 @@ public class AppTest
     {
     	DeathCertificateDocument deathCertificateDocument = BuildDCD.buildExampleDeathCertificateDocument();
     	String encoded = context.getCtx().newJsonParser().encodeResourceToString(deathCertificateDocument);
-    	System.out.println(encoded);
-    	assertTrue( true );
+    	assertTrue(encoded != null && encoded.length() > 0);
     }
     
     public void testConsumingDeathCertificateDocument()
@@ -66,8 +65,7 @@ public class AppTest
 			e.printStackTrace();
 		}
     	String encoded = context.getCtx().newJsonParser().encodeResourceToString(deathCertificateDocument);
-    	System.out.println(encoded);
-    	assertTrue( true );
+		assertTrue(encoded != null && encoded.length() > 0);
     }
     
     public void testGetResourceFromDocument() {
@@ -75,19 +73,19 @@ public class AppTest
     	List<MannerOfDeath> mannerOfDeathList = deathCertificateDocument.getMannerOfDeath();
     	for(MannerOfDeath manner:mannerOfDeathList) {
     		String jsonForm = context.getCtx().newJsonParser().encodeResourceToString(manner);
-    		System.out.println(jsonForm);
+			assertTrue(jsonForm != null && jsonForm.length() > 0);
     	}
     }
     
     public void testPartialDecedentBirthDateRecord() {
     	Decedent decedent = BuildDCD.buildDecedentWithBirthDateAbsentReason();
     	String jsonForm = context.getCtx().newJsonParser().encodeResourceToString(decedent);
-		System.out.println(jsonForm);
+		assertTrue(jsonForm != null && jsonForm.length() > 0);
     }
     
     public void testPartialDeathDateRecord() {
     	DeathDate deathDate = BuildDCD.buildDeathWithPartialDateAbsentReason();
     	String jsonForm = context.getCtx().newJsonParser().encodeResourceToString(deathDate);
-		System.out.println(jsonForm);
+		assertTrue(jsonForm != null && jsonForm.length() > 0);
     }
 }

--- a/src/test/java/edu/gatech/VRDR/MessagingTest.java
+++ b/src/test/java/edu/gatech/VRDR/MessagingTest.java
@@ -11,6 +11,7 @@ import edu.gatech.chai.VRDR.model.util.MannerOfDeathUtil;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
+import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.StringType;
 
@@ -859,7 +860,7 @@ public class MessagingTest extends TestCase {
         assertTrue(submissionBundleStr.contains("{\"code\":{\"coding\":[{\"system\":\"http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs\",\"code\":\"AmericanIndianOrAlaskanNative\"}]},\"valueBoolean\":true}"));
         assertTrue(submissionBundleStr.contains("{\"code\":{\"coding\":[{\"system\":\"http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs\",\"code\":\"FirstAmericanIndianOrAlaskanNativeLiteral\"}]},\"valueString\":\"Apache\"}"));
         assertTrue(submissionBundleStr.contains("{\"code\":{\"coding\":[{\"system\":\"http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs\",\"code\":\"SecondAmericanIndianOrAlaskanNativeLiteral\"}]},\"valueString\":\"Lipan Apache\"}"));
-        assertTrue(submissionBundleStr.contains("{\"code\":{\"coding\":[{\"system\":\"http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs\",\"code\":\"HispanicOther\"}]},\"valueCodeableConcept\":{\"coding\":[{\"system\":\"http://hl7.org/CodeSystem/v2-0136\",\"code\":\"Y\",\"display\":\"Yes\"}]}}"));
+        assertTrue(submissionBundleStr.contains("{\"code\":{\"coding\":[{\"system\":\"http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs\",\"code\":\"HispanicOther\"}]},\"valueCodeableConcept\":{\"coding\":[{\"system\":\"http://terminology.hl7.org/CodeSystem/v2-0136\",\"code\":\"Y\",\"display\":\"Yes\"}]}}"));
 
         DeathRecordSubmissionMessage parsed = BaseMessage.parseJson(DeathRecordSubmissionMessage.class, ctx, submissionBundleStr);
         assertNotNull(parsed); // make sure we can parse the race values without crashing

--- a/src/test/java/edu/gatech/VRDR/MessagingTest.java
+++ b/src/test/java/edu/gatech/VRDR/MessagingTest.java
@@ -332,7 +332,8 @@ public class MessagingTest extends TestCase {
     }
 
     public void testCreateAckFromJSON() {
-        AcknowledgementMessage ack = BaseMessage.parseJsonFile(AcknowledgementMessage.class, ctx, "src/test/resources/json/AcknowledgementMessage.json");
+        AcknowledgementMessage ack = BaseMessage.parseJsonFile(AcknowledgementMessage.class, ctx,
+                "src/test/resources/json/AcknowledgementMessage.json");
         assertEquals("http://nchs.cdc.gov/vrdr_acknowledgement", ack.getMessageType());
         assertEquals("a9d66d2e-2480-4e8d-bab3-4e4c761da1b7", ack.getAckedMessageId());
         assertEquals("nightingale", ack.getMessageDestination());
@@ -367,7 +368,8 @@ public class MessagingTest extends TestCase {
     }
 
     public void testCreateCauseOfDeathCodingResponseFromJSON() {
-        CauseOfDeathCodingMessage message = BaseMessage.parseJsonFile(CauseOfDeathCodingMessage.class, ctx, "src/test/resources/json/CauseOfDeathCodingMessage.json");
+        CauseOfDeathCodingMessage message = BaseMessage.parseJsonFile(CauseOfDeathCodingMessage.class, ctx,
+                "src/test/resources/json/CauseOfDeathCodingMessage.json");
 
         assertEquals(CauseOfDeathCodingMessage.MESSAGE_TYPE, message.getMessageType());
         assertEquals("http://nchs.cdc.gov/vrdr_submission", message.getMessageDestination());
@@ -627,7 +629,8 @@ public class MessagingTest extends TestCase {
     }
 
     public void testCreateAckForStatusMessage() {
-        StatusMessage statusMessage = BaseMessage.parseJsonFile(StatusMessage.class, ctx, "src/test/resources/json/StatusMessage.json");
+        StatusMessage statusMessage = BaseMessage.parseJsonFile(StatusMessage.class, ctx,
+                "src/test/resources/json/StatusMessage.json");
         AcknowledgementMessage ack = new AcknowledgementMessage(statusMessage);
         assertEquals("http://nchs.cdc.gov/vrdr_acknowledgement", ack.getMessageType());
         assertEquals(statusMessage.getMessageId(), ack.getAckedMessageId());
@@ -813,7 +816,8 @@ public class MessagingTest extends TestCase {
     }
 
     public void testCreateExtractionErrorFromJson() {
-        ExtractionErrorMessage err = BaseMessage.parseJsonFile(ExtractionErrorMessage.class, ctx, "src/test/resources/json/ExtractionErrorMessage.json");
+        ExtractionErrorMessage err = BaseMessage.parseJsonFile(ExtractionErrorMessage.class, ctx,
+                "src/test/resources/json/ExtractionErrorMessage.json");
         assertEquals("http://nchs.cdc.gov/vrdr_extraction_error", err.getMessageType());
         assertEquals((long) 1, (long) err.getCertNo());
         assertEquals("42", err.getStateAuxiliaryId());

--- a/src/test/java/edu/gatech/VRDR/MessagingTest.java
+++ b/src/test/java/edu/gatech/VRDR/MessagingTest.java
@@ -861,7 +861,6 @@ public class MessagingTest extends TestCase {
         assertTrue(submissionBundleStr.contains("{\"code\":{\"coding\":[{\"system\":\"http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs\",\"code\":\"FirstAmericanIndianOrAlaskanNativeLiteral\"}]},\"valueString\":\"Apache\"}"));
         assertTrue(submissionBundleStr.contains("{\"code\":{\"coding\":[{\"system\":\"http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs\",\"code\":\"SecondAmericanIndianOrAlaskanNativeLiteral\"}]},\"valueString\":\"Lipan Apache\"}"));
         assertTrue(submissionBundleStr.contains("{\"code\":{\"coding\":[{\"system\":\"http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs\",\"code\":\"HispanicOther\"}]},\"valueCodeableConcept\":{\"coding\":[{\"system\":\"http://terminology.hl7.org/CodeSystem/v2-0136\",\"code\":\"Y\",\"display\":\"Yes\"}]}}"));
-
         DeathRecordSubmissionMessage parsed = BaseMessage.parseJson(DeathRecordSubmissionMessage.class, ctx, submissionBundleStr);
         assertNotNull(parsed); // make sure we can parse the race values without crashing
     }

--- a/src/test/java/edu/gatech/VRDR/MessagingTest.java
+++ b/src/test/java/edu/gatech/VRDR/MessagingTest.java
@@ -2,7 +2,7 @@ package edu.gatech.VRDR;
 
 import edu.gatech.chai.VRDR.context.VRDRFhirContext;
 import edu.gatech.chai.VRDR.messaging.*;
-import edu.gatech.chai.VRDR.messaging.util.BaseMessage;
+import edu.gatech.chai.VRDR.messaging.BaseMessage;
 import edu.gatech.chai.VRDR.messaging.util.MessageParseException;
 import edu.gatech.chai.VRDR.model.*;
 import edu.gatech.chai.VRDR.model.util.CodedRaceAndEthnicityUtil;
@@ -11,7 +11,6 @@ import edu.gatech.chai.VRDR.model.util.MannerOfDeathUtil;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
-import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.StringType;
 
@@ -44,9 +43,9 @@ public class MessagingTest extends TestCase {
         assertEquals("http://nchs.cdc.gov/vrdr_submission", submission.getMessageType());
         assertNull(submission.getDeathRecord());
         assertEquals("http://nchs.cdc.gov/vrdr_submission", submission.getMessageDestination());
-        assertNotNull(submission.getMessageTimestamp());
+        assertNotNull(submission.getTimestamp());
         assertNull(submission.getMessageSource());
-        assertNotNull(submission.getMessageId());
+        assertNotNull(submission.getId());
         assertNull(submission.getCertNo());
         assertNull(submission.getStateAuxiliaryId());
         assertNull(submission.getNCHSIdentifier());
@@ -124,7 +123,7 @@ public class MessagingTest extends TestCase {
             ExtractionErrorMessage errMsg = ex.createExtractionErrorMessage();
             assertEquals("http://nchs.cdc.gov/vrdr_submission", errMsg.getMessageSource());
             assertEquals("nightingale", errMsg.getMessageDestination());
-            assertEquals("urn:uuid:a9d66d2e-2480-4e8d-bab3-4e4c761da1b7", errMsg.getFailedMessageId());
+            assertEquals("254b5d1e-6620-4b49-8d25-4f38f4562016", errMsg.getFailedMessageId());
             assertEquals("2018MA000001", errMsg.getNCHSIdentifier());
             assertEquals(1, errMsg.getCertNo().intValue());
             assertEquals(2018, errMsg.getDeathYear().intValue());
@@ -146,10 +145,11 @@ public class MessagingTest extends TestCase {
         submission.setDeathRecord(new DeathCertificateDocument());
         submission.setCertNo(42);
         submission.setStateAuxiliaryId("identifier");
-        String submissionBundleStr = submission.toJson(ctx);
+        final String submissionBundleStr = submission.toJson(ctx);
 
         DeathRecordSubmissionMessage parsed = BaseMessage.parseJson(DeathRecordSubmissionMessage.class, ctx, submissionBundleStr);
-        assertEquals(submission.getDeathRecord().toJson(ctx), parsed.getDeathRecord().toJson(ctx));
+        final String parsedBundleStr = parsed.toJson(ctx);
+        assertEquals(submissionBundleStr, parsedBundleStr);
         assertEquals(submission.getMessageType(), parsed.getMessageType());
         assertEquals(submission.getCertNo(), parsed.getCertNo());
         assertEquals(submission.getStateAuxiliaryId(), parsed.getStateAuxiliaryId());
@@ -161,9 +161,9 @@ public class MessagingTest extends TestCase {
         assertEquals("http://nchs.cdc.gov/vrdr_submission_update", submission.getMessageType());
         assertNull(submission.getDeathRecord());
         assertEquals("http://nchs.cdc.gov/vrdr_submission", submission.getMessageDestination());
-        assertNotNull(submission.getMessageTimestamp());
+        assertNotNull(submission.getTimestamp());
         assertNull(submission.getMessageSource());
-        assertNotNull(submission.getMessageId());
+        assertNotNull(submission.getId());
         assertNull(submission.getCertNo());
         assertNull(submission.getStateAuxiliaryId());
         assertNull(submission.getNCHSIdentifier());
@@ -194,10 +194,11 @@ public class MessagingTest extends TestCase {
         DeathRecordUpdateMessage update = BaseMessage.parseJsonFile(DeathRecordUpdateMessage.class, ctx, "src/test/resources/json/DeathRecordUpdateMessage.json");
         assertEquals("2020-11-13T16:39:40-05:00", update.getDeathRecord().getDateOfDeathPronouncement());
         assertEquals("http://nchs.cdc.gov/vrdr_submission_update", update.getMessageType());
-        assertEquals("2018NY123456", update.getNCHSIdentifier());
-        assertEquals(123456, update.getCertNo().intValue());
-        assertEquals(2018, update.getDeathYear().intValue());
-        assertEquals("abcdef10", update.getStateAuxiliaryId());
+        assertEquals("2020NY000182", update.getNCHSIdentifier());
+        assertEquals("NY", update.getJurisdictionId());
+        assertEquals(182, update.getCertNo().intValue());
+        assertEquals(2020, update.getDeathYear().intValue());
+        assertEquals("000000000001", update.getStateAuxiliaryId());
     }
 
     public void testCreateUpdateFromJsonNoIdentifiers() {
@@ -229,7 +230,7 @@ public class MessagingTest extends TestCase {
                 "src/test/resources/json/DeathRecordSubmissionMessage.json");
         AcknowledgementMessage ack = new AcknowledgementMessage(submission);
         assertEquals("http://nchs.cdc.gov/vrdr_acknowledgement", ack.getMessageType());
-        assertEquals(submission.getMessageId(), ack.getAckedMessageId());
+        assertEquals(submission.getId(), ack.getAckedMessageId());
         assertEquals(submission.getMessageSource(), ack.getMessageDestination());
         assertEquals(submission.getMessageDestination(), ack.getMessageSource());
         assertEquals(submission.getStateAuxiliaryId(), ack.getStateAuxiliaryId());
@@ -252,7 +253,7 @@ public class MessagingTest extends TestCase {
         DeathRecordSubmissionMessage submission = new DeathRecordSubmissionMessage();
         AcknowledgementMessage ack = new AcknowledgementMessage(submission);
         assertEquals("http://nchs.cdc.gov/vrdr_acknowledgement", ack.getMessageType());
-        assertEquals(submission.getMessageId(), ack.getAckedMessageId());
+        assertEquals(submission.getId(), ack.getAckedMessageId());
         assertEquals(submission.getMessageSource(), ack.getMessageDestination());
         assertEquals(submission.getMessageDestination(), ack.getMessageSource());
         assertEquals(submission.getStateAuxiliaryId(), ack.getStateAuxiliaryId());
@@ -265,7 +266,7 @@ public class MessagingTest extends TestCase {
                 "src/test/resources/json/DeathRecordSubmissionMessage.json");
         CauseOfDeathCodingMessage coding = new CauseOfDeathCodingMessage(submission);
         assertEquals("http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-CauseOfDeathCodingMessage", coding.getMessageType());
-        assertEquals(submission.getMessageId(), coding.getCodedMessageId());
+        assertEquals(submission.getId(), coding.getCodedMessageId());
         assertEquals(submission.getMessageSource(), coding.getMessageDestination());
         assertEquals(submission.getMessageDestination(), coding.getMessageSource());
         assertEquals(submission.getStateAuxiliaryId(), coding.getStateAuxiliaryId());
@@ -288,7 +289,7 @@ public class MessagingTest extends TestCase {
         DeathRecordSubmissionMessage submission = new DeathRecordSubmissionMessage();
         CauseOfDeathCodingMessage coding = new CauseOfDeathCodingMessage(submission);
         assertEquals("http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-CauseOfDeathCodingMessage", coding.getMessageType());
-        assertEquals(submission.getMessageId(), coding.getCodedMessageId());
+        assertEquals(submission.getId(), coding.getCodedMessageId());
         assertEquals(submission.getMessageSource(), coding.getMessageDestination());
         assertEquals(submission.getMessageDestination(), coding.getMessageSource());
         assertEquals(submission.getStateAuxiliaryId(), coding.getStateAuxiliaryId());
@@ -300,7 +301,7 @@ public class MessagingTest extends TestCase {
         DeathRecordSubmissionMessage submission = BaseMessage.parseJsonFile(DeathRecordSubmissionMessage.class, ctx, "src/test/resources/json/DeathRecordSubmissionMessage.json");
         DemographicsCodingMessage coding = new DemographicsCodingMessage(submission);
         assertEquals("http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-DemographicsCodingMessage", coding.getMessageType());
-        assertEquals(submission.getMessageId(), coding.getCodedMessageId());
+        assertEquals(submission.getId(), coding.getCodedMessageId());
         assertEquals(submission.getMessageSource(), coding.getMessageDestination());
         assertEquals(submission.getMessageDestination(), coding.getMessageSource());
         assertEquals(submission.getStateAuxiliaryId(), coding.getStateAuxiliaryId());
@@ -323,7 +324,7 @@ public class MessagingTest extends TestCase {
         DeathRecordSubmissionMessage submission = new DeathRecordSubmissionMessage();
         DemographicsCodingMessage coding = new DemographicsCodingMessage(submission);
         assertEquals("http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-DemographicsCodingMessage", coding.getMessageType());
-        assertEquals(submission.getMessageId(), coding.getCodedMessageId());
+        assertEquals(submission.getId(), coding.getCodedMessageId());
         assertEquals(submission.getMessageSource(), coding.getMessageDestination());
         assertEquals(submission.getMessageDestination(), coding.getMessageSource());
         assertEquals(submission.getStateAuxiliaryId(), coding.getStateAuxiliaryId());
@@ -355,9 +356,8 @@ public class MessagingTest extends TestCase {
     }
 
     public void testCreateAckFromBundle() {
-        AcknowledgementMessage ackFixture = BaseMessage.parseJsonFile(AcknowledgementMessage.class, ctx, "src/test/resources/json/AcknowledgementMessage.json");
-        Bundle ackBundle = ackFixture.getMessageBundle();
-        String bundleString = BaseMessage.bundleToJson(ctx, ackBundle);
+        AcknowledgementMessage ackBundle = BaseMessage.parseJsonFile(AcknowledgementMessage.class, ctx, "src/test/resources/json/AcknowledgementMessage.json");
+        String bundleString = ackBundle.toJson(ctx, false);
         AcknowledgementMessage ack = BaseMessage.parseJson(AcknowledgementMessage.class, ctx, bundleString);
         assertEquals("a9d66d2e-2480-4e8d-bab3-4e4c761da1b7", ack.getAckedMessageId());
         assertEquals("nightingale", ack.getMessageDestination());
@@ -562,7 +562,7 @@ public class MessagingTest extends TestCase {
         StatusMessage status = new StatusMessage(submission, "manualCauseOfDeathCoding");
         assertEquals("http://nchs.cdc.gov/vrdr_status", status.getMessageType());
         assertEquals("manualCauseOfDeathCoding", status.getStatus());
-        assertEquals(submission.getMessageId(), status.getStatusedMessageId());
+        assertEquals(submission.getId(), status.getStatusedMessageId());
         assertEquals(submission.getMessageSource(), status.getMessageDestination());
         assertEquals(submission.getMessageDestination(), status.getMessageSource());
         assertEquals(submission.getStateAuxiliaryId(), status.getStateAuxiliaryId());
@@ -584,7 +584,7 @@ public class MessagingTest extends TestCase {
         status = new StatusMessage(submission, "manualCauseOfDeathCoding");
         assertEquals("http://nchs.cdc.gov/vrdr_status", status.getMessageType());
         assertEquals("manualCauseOfDeathCoding", status.getStatus());
-        assertEquals(submission.getMessageId(), status.getStatusedMessageId());
+        assertEquals(submission.getId(), status.getStatusedMessageId());
         assertEquals(submission.getMessageSource(), status.getMessageDestination());
         assertEquals(submission.getMessageDestination(), status.getMessageSource());
         assertEquals(submission.getStateAuxiliaryId(), status.getStateAuxiliaryId());
@@ -597,7 +597,7 @@ public class MessagingTest extends TestCase {
         DeathRecordVoidMessage voidMessage = BaseMessage.parseJsonFile(DeathRecordVoidMessage.class, ctx, "src/test/resources/json/DeathRecordVoidMessage.json");
         AcknowledgementMessage ack = new AcknowledgementMessage(voidMessage);
         assertEquals("http://nchs.cdc.gov/vrdr_acknowledgement", ack.getMessageType());
-        assertEquals(voidMessage.getMessageId(), ack.getAckedMessageId());
+        assertEquals(voidMessage.getId(), ack.getAckedMessageId());
         assertEquals(voidMessage.getMessageSource(), ack.getMessageDestination());
         assertEquals(voidMessage.getMessageDestination(), ack.getMessageSource());
         assertEquals(voidMessage.getStateAuxiliaryId(), ack.getStateAuxiliaryId());
@@ -619,7 +619,7 @@ public class MessagingTest extends TestCase {
         voidMessage = new DeathRecordVoidMessage();
         ack = new AcknowledgementMessage(voidMessage);
         assertEquals("http://nchs.cdc.gov/vrdr_acknowledgement", ack.getMessageType());
-        assertEquals(voidMessage.getMessageId(), ack.getAckedMessageId());
+        assertEquals(voidMessage.getId(), ack.getAckedMessageId());
         assertEquals(voidMessage.getMessageSource(), ack.getMessageDestination());
         assertEquals(voidMessage.getMessageDestination(), ack.getMessageSource());
         assertEquals(voidMessage.getStateAuxiliaryId(), ack.getStateAuxiliaryId());
@@ -633,7 +633,7 @@ public class MessagingTest extends TestCase {
                 "src/test/resources/json/StatusMessage.json");
         AcknowledgementMessage ack = new AcknowledgementMessage(statusMessage);
         assertEquals("http://nchs.cdc.gov/vrdr_acknowledgement", ack.getMessageType());
-        assertEquals(statusMessage.getMessageId(), ack.getAckedMessageId());
+        assertEquals(statusMessage.getId(), ack.getAckedMessageId());
         assertEquals(statusMessage.getMessageSource(), ack.getMessageDestination());
         assertEquals(statusMessage.getMessageDestination(), ack.getMessageSource());
         assertEquals(statusMessage.getStateAuxiliaryId(), ack.getStateAuxiliaryId());
@@ -653,7 +653,7 @@ public class MessagingTest extends TestCase {
         statusMessage = new StatusMessage();
         ack = new AcknowledgementMessage(statusMessage);
         assertEquals("http://nchs.cdc.gov/vrdr_acknowledgement", ack.getMessageType());
-        assertEquals(statusMessage.getMessageId(), ack.getAckedMessageId());
+        assertEquals(statusMessage.getId(), ack.getAckedMessageId());
         assertEquals(statusMessage.getMessageSource(), ack.getMessageDestination());
         assertEquals(statusMessage.getMessageDestination(), ack.getMessageSource());
         assertEquals(statusMessage.getStateAuxiliaryId(), ack.getStateAuxiliaryId());
@@ -734,7 +734,7 @@ public class MessagingTest extends TestCase {
         DeathRecordAliasMessage message = BaseMessage.parseJsonFile(DeathRecordAliasMessage.class, ctx, "src/test/resources/json/DeathRecordAliasMessage.json");
         AcknowledgementMessage ack = new AcknowledgementMessage(message);
         assertEquals("http://nchs.cdc.gov/vrdr_acknowledgement", ack.getMessageType());
-        assertEquals(message.getMessageId(), ack.getAckedMessageId());
+        assertEquals(message.getId(), ack.getAckedMessageId());
         assertEquals(message.getMessageSource(), ack.getMessageDestination());
         assertEquals(message.getMessageDestination(), ack.getMessageSource());
         assertEquals(message.getStateAuxiliaryId(), ack.getStateAuxiliaryId());
@@ -782,7 +782,7 @@ public class MessagingTest extends TestCase {
         DeathRecordSubmissionMessage submission = BaseMessage.parseJsonFile(DeathRecordSubmissionMessage.class, ctx, "src/test/resources/json/DeathRecordSubmissionMessage.json");
         ExtractionErrorMessage err = new ExtractionErrorMessage(submission);
         assertEquals("http://nchs.cdc.gov/vrdr_extraction_error", err.getMessageType());
-        assertEquals(submission.getMessageId(), err.getFailedMessageId());
+        assertEquals(submission.getId(), err.getFailedMessageId());
         assertEquals(submission.getMessageSource(), err.getMessageDestination());
         assertEquals(submission.getStateAuxiliaryId(), err.getStateAuxiliaryId());
         assertEquals(submission.getCertNo(), err.getCertNo());

--- a/src/test/resources/json/CauseOfDeathCodingMessage.json
+++ b/src/test/resources/json/CauseOfDeathCodingMessage.json
@@ -50,7 +50,7 @@
         "id": "3ef10003-c427-4da6-bce2-f2dfef056ee7",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-coded-content-bundle"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-coded-bundle"
           ]
         },
         "identifier": {

--- a/src/test/resources/json/CauseOfDeathCodingUpdateMessage.json
+++ b/src/test/resources/json/CauseOfDeathCodingUpdateMessage.json
@@ -50,7 +50,7 @@
         "id": "38cfee56-e22b-4cfc-8a1c-0be9ec7bff9c",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-coded-content-bundle"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-coded-bundle"
           ]
         },
         "identifier": {

--- a/src/test/resources/json/DeathRecordUpdateMessage.json
+++ b/src/test/resources/json/DeathRecordUpdateMessage.json
@@ -51,15 +51,15 @@
           },
           {
             "name": "cert_no",
-            "valueUnsignedInt": 123456
+            "valueUnsignedInt": 182
           },
           {
             "name": "death_year",
-            "valueUnsignedInt": 2018
+            "valueUnsignedInt": 2020
           },
           {
             "name": "state_auxiliary_id",
-            "valueString": "abcdef10"
+            "valueString": "000000000001"
           }
         ]
       },

--- a/src/test/resources/json/DemographicsCodingMessage.json
+++ b/src/test/resources/json/DemographicsCodingMessage.json
@@ -54,7 +54,7 @@
         "id": "1c8f5cb8-e124-449b-9e10-b9ecd53f3b7f",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-demographic-coded-content-bundle"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-demographic-coded-bundle"
           ]
         },
         "identifier": {

--- a/src/test/resources/json/DemographicsCodingUpdateMessage.json
+++ b/src/test/resources/json/DemographicsCodingUpdateMessage.json
@@ -54,7 +54,7 @@
         "id": "c593f782-7f64-450a-8aca-aea4f8130217",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-demographic-coded-content-bundle"
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-demographic-coded-bundle"
           ]
         },
         "identifier": {


### PR DESCRIPTION
A refactoring after many issues were found during testing with UT:

* Corrects many invalid VRDR IG urls in the profiles
* Sets proper codes and values for components, systems, values
* Fixes "urn:uuid:" prefix being added where it shouldn't or not added when it should
* Refactors handling of message classes as bundles themselves replacing inner message pseudo-bundle
* BaseMessage changed from abstract to real class and moved to same package as other message classes
* All unit tests now passing after changes
* Many thanks to Aihua Tong at UT for contributing much of this patch